### PR TITLE
Update Kubernetes scripts for Composer v0.12.0

### DIFF
--- a/cs-offerings/free/kube-configs/.gitignore
+++ b/cs-offerings/free/kube-configs/.gitignore
@@ -2,3 +2,4 @@ create_channel.yaml
 join_channel.yaml
 chaincode_install.yaml
 chaincode_instantiate.yaml
+composer-rest-server.yaml

--- a/cs-offerings/free/kube-configs/composer-playground.yaml
+++ b/cs-offerings/free/kube-configs/composer-playground.yaml
@@ -22,9 +22,19 @@ spec:
         - name: COMPOSER_CONFIG
           value: >
             {
-              "defaultConnectionProfile": "hlfv1",
-              "connectionProfiles": {
-                "hlfv1": {
+              "cards": [{
+                "metadata": {
+                  "name": "PeerAdmin",
+                  "enrollmentId": "PeerAdmin",
+                  "enrollmentSecret": "NOTUSED",
+                  "roles": [
+                    "PeerAdmin",
+                    "ChannelAdmin"
+                  ]
+                },
+                "connectionProfile": {
+                  "name": "hlfv1",
+                  "description": "Hyperledger Fabric v1.0",
                   "type": "hlfv1",
                   "orderers": [
                       {
@@ -44,15 +54,10 @@ spec:
                   "keyValStore": "/home/composer/.hfc-key-store",
                   "channel": "channel1",
                   "mspID": "Org1MSP",
-                  "timeout": "300"
-                }
-              },
-              "credentials": {
-                "hlfv1": {
-                  "PeerAdmin": "notneeded",
-                  "admin": "adminpw"
-                }
-              }
+                  "timeout": 300
+                },
+                "credentials": null
+              }]
             }
         volumeMounts:
         - name: composer-credentials

--- a/cs-offerings/free/kube-configs/composer-rest-server.yaml.base
+++ b/cs-offerings/free/kube-configs/composer-rest-server.yaml.base
@@ -53,7 +53,7 @@ spec:
         - name: COMPOSER_CONNECTION_PROFILE
           value: hlfv1
         - name: COMPOSER_BUSINESS_NETWORK
-          value: org-acme-biznet
+          value: %COMPOSER_BUSINESS_NETWORK%
         - name: COMPOSER_ENROLLMENT_ID
           value: admin
         - name: COMPOSER_ENROLLMENT_SECRET

--- a/cs-offerings/free/kube-configs/wipe_shared.yaml
+++ b/cs-offerings/free/kube-configs/wipe_shared.yaml
@@ -5,16 +5,21 @@ metadata:
   name: wipeshared
 spec:
   restartPolicy: "Never"
-  volumes: 
+  volumes:
+  - name: composer-credentials
+    hostPath:
+      path: /composer
   - name: shared
     hostPath:
       path: /tmp
-        
+
   containers:
   - name: wipeshared
     image: ibmblockchain/fabric-tools:1.0.1
     imagePullPolicy: Always
-    command: ["sh", "-c", "rm -rf /shared/*"]
+    command: ["sh", "-c", "rm -rf /shared/* /home/*"]
     volumeMounts:
+    - name: composer-credentials
+      mountPath: /home
     - mountPath: /shared
       name: shared

--- a/cs-offerings/free/scripts/create/create_composer-rest-server.sh
+++ b/cs-offerings/free/scripts/create/create_composer-rest-server.sh
@@ -8,6 +8,15 @@ else
     echo "Please run the script from 'scripts' or 'scripts/create' folder"
 fi
 
+COMPOSER_BUSINESS_NETWORK=$1
+if [ -z ${COMPOSER_BUSINESS_NETWORK} ]; then
+	echo "Usage: $0 <businessNetworkId>"
+    exit 1
+fi
+
+echo "Preparing yaml file for create composer-rest-server"
+sed -e "s/%COMPOSER_BUSINESS_NETWORK%/${COMPOSER_BUSINESS_NETWORK}/g" ${KUBECONFIG_FOLDER}/composer-rest-server.yaml.base > ${KUBECONFIG_FOLDER}/composer-rest-server.yaml
+
 echo "Creating composer-rest-server pod"
 echo "Running: kubectl create -f ${KUBECONFIG_FOLDER}/composer-rest-server.yaml"
 kubectl create -f ${KUBECONFIG_FOLDER}/composer-rest-server.yaml


### PR DESCRIPTION
In Composer v0.12.0 we have introduced ID cards.
This requires new environment variables for playground.
Whilst working on this, I found that a change to move the volume mount for the Composer files meant that the credentials get persisted during a recreate (delete_all/create_all) so fixing that as well.
The REST server script also needs to prompt for the business network name now that it won't always be called `org-acme-biznet`.