### PR TITLE
Redirect chaincode logs to peer container

### DIFF
--- a/cs-offerings/free/kube-configs/blockchain.yaml
+++ b/cs-offerings/free/kube-configs/blockchain.yaml
@@ -239,6 +239,8 @@ spec:
           value: blockchain-orderer:31010
         - name: GODEBUG
           value: "netdns=go"
+        - name: CORE_VM_DOCKER_ATTACHSTDOUT
+          value: "true"
         volumeMounts:
         - mountPath: /shared
           name: shared
@@ -329,6 +331,8 @@ spec:
           value: blockchain-orderer:31010
         - name: GODEBUG
           value: "netdns=go"
+        - name: CORE_VM_DOCKER_ATTACHSTDOUT
+          value: "true"
         volumeMounts:
         - mountPath: /shared
           name: shared


### PR DESCRIPTION
Added the flag to redirect the chaincode container logs to the peer c
ontainer for debugging purposes

CORE_VM_DOCKER_ATTACHSTDOUT=true

Signed-off-by: asararatnakar <asara.ratnakar@gmail.com>