### PR TITLE
fix level of composer for k8s

### DIFF
--- a/cs-offerings/kube-configs/composer-playground.yaml
+++ b/cs-offerings/kube-configs/composer-playground.yaml
@@ -16,7 +16,7 @@ spec:
           claimName: composer-pvc
       containers:
       - name: composer-playground
-        image: hyperledger/composer-playground
+        image: hyperledger/composer-playground:0.13.2
         imagePullPolicy: Always
         env:
         - name: COMPOSER_CONFIG

--- a/cs-offerings/kube-configs/composer-rest-server.yaml.base
+++ b/cs-offerings/kube-configs/composer-rest-server.yaml.base
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
       - name: composer-rest-server
-        image: hyperledger/composer-rest-server
+        image: hyperledger/composer-rest-server:0.13.2
         imagePullPolicy: Always
         env:
         - name: COMPOSER_CONFIG


### PR DESCRIPTION
v0.14.0 now requires the admin identity to be the same between services which currently isn’t possible in the K8s environment, so need to fix the level of composer to 0.13.2 for now to ensure they continue to work.

Signed-off-by: Dave Kelsey <d_kelsey@uk.ibm.com>