### PR TITLE
Update IBM Container Service scripts to use latest Hyperledger Composer

### DIFF
--- a/cs-offerings/kube-configs/blockchain-couchdb-services-free.yaml
+++ b/cs-offerings/kube-configs/blockchain-couchdb-services-free.yaml
@@ -11,9 +11,9 @@ spec:
     name: ca
   ports:
   - protocol: TCP
-    nodePort: 30000
+    nodePort: 30054
     targetPort: 7054
-    port: 30000
+    port: 30054
     name: grpc
 ---
 apiVersion: v1

--- a/cs-offerings/kube-configs/blockchain-couchdb-services-paid.yaml
+++ b/cs-offerings/kube-configs/blockchain-couchdb-services-paid.yaml
@@ -14,7 +14,7 @@ spec:
   ports:
   - protocol: TCP
     port: 7054
-    nodePort: 30000
+    nodePort: 30054
     name: grpc
 ---
 apiVersion: v1

--- a/cs-offerings/kube-configs/blockchain-couchdb.yaml
+++ b/cs-offerings/kube-configs/blockchain-couchdb.yaml
@@ -48,11 +48,11 @@ spec:
   - name: bootstrap
     image: ibmblockchain/fabric-tools:1.0.3
     imagePullPolicy: Always
-    command: ["sh", "-c", "sleep 1 && while [ ! -f /shared/status_configtxgen_complete ]; do echo Waiting for configtxgen; sleep 1; done && cp -r /sampleconfig/cas /shared && touch /shared/bootstrapped && rm /shared/status_configtxgen_complete && mkdir -p /home/composer && chown 100 /home/composer && echo 'Done with bootstrapping'" ]
+    command: ["sh", "-c", "sleep 1 && while [ ! -f /shared/status_configtxgen_complete ]; do echo Waiting for configtxgen; sleep 1; done && cp -r /sampleconfig/cas /shared && touch /shared/bootstrapped && rm /shared/status_configtxgen_complete && mkdir -p /home/composer/.hfc-key-store && chown 100 /home/composer/.hfc-key-store && echo 'Done with bootstrapping'" ]
     volumeMounts:
     - mountPath: /shared
       name: shared
-    - mountPath: /home
+    - mountPath: /home/composer/.hfc-key-store
       name: composer-credentials
 ---
 apiVersion: extensions/v1beta1

--- a/cs-offerings/kube-configs/blockchain-couchdb.yaml
+++ b/cs-offerings/kube-configs/blockchain-couchdb.yaml
@@ -17,14 +17,14 @@ spec:
       claimName: composer-pvc
   containers:
   - name: cryptogen
-    image: ibmblockchain/fabric-tools:1.0.1
+    image: ibmblockchain/fabric-tools:1.0.3
     imagePullPolicy: Always
     command: ["sh", "-c", "cryptogen generate --config /sampleconfig/crypto-config.yaml && cp -r crypto-config /shared/ && for file in $(find /shared/ -iname *_sk); do dir=$(dirname $file); mv ${dir}/*_sk ${dir}/key.pem; done && find /shared -type d | xargs chmod a+rx && find /shared -type f | xargs chmod a+r && touch /shared/status_cryptogen_complete "]
     volumeMounts:
     - mountPath: /shared
       name: shared
   - name: configtxgen
-    image: ibmblockchain/fabric-tools:1.0.1
+    image: ibmblockchain/fabric-tools:1.0.3
     imagePullPolicy: Always
     command: ["sh", "-c", "sleep 1 && while [ ! -f /shared/status_cryptogen_complete ]; do echo Waiting for cryptogen; sleep 1; done; cp /sampleconfig/configtx.yaml /shared/configtx.yaml; cd /shared/; configtxgen -profile TwoOrgsOrdererGenesis -outputBlock orderer.block && find /shared -type d | xargs chmod a+rx && find /shared -type f | xargs chmod a+r && touch /shared/status_configtxgen_complete && rm /shared/status_cryptogen_complete"]
     env:
@@ -46,7 +46,7 @@ spec:
     - mountPath: /shared
       name: shared
   - name: bootstrap
-    image: ibmblockchain/fabric-tools:1.0.1
+    image: ibmblockchain/fabric-tools:1.0.3
     imagePullPolicy: Always
     command: ["sh", "-c", "sleep 1 && while [ ! -f /shared/status_configtxgen_complete ]; do echo Waiting for configtxgen; sleep 1; done && cp -r /sampleconfig/cas /shared && touch /shared/bootstrapped && rm /shared/status_configtxgen_complete && mkdir -p /home/composer && chown 100 /home/composer && echo 'Done with bootstrapping'" ]
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
 
       containers:
       - name: orderer
-        image: ibmblockchain/fabric-orderer:1.0.1
+        image: ibmblockchain/fabric-orderer:1.0.3
         command: ["sh", "-c", "sleep 5 && while [ ! -f /shared/bootstrapped ]; do echo Waiting for bootstrap; sleep 1; done; orderer"]
         env:
         - name: ORDERER_CFG_PATH
@@ -133,7 +133,7 @@ spec:
 
       containers:
       - name: ca
-        image: ibmblockchain/fabric-ca:1.0.1
+        image: ibmblockchain/fabric-ca:1.0.3
         command: ["sh", "-c", "sleep 1 && while [ ! -f /shared/bootstrapped ]; do echo Waiting for bootstrap; sleep 1; done; fabric-ca-server start -c ${CONFIGYAML}"]
         env:
         - name: CONFIGYAML
@@ -178,7 +178,7 @@ spec:
 
       containers:
       - name: org1peer1
-        image: ibmblockchain/fabric-peer:1.0.1
+        image: ibmblockchain/fabric-peer:1.0.3
         command: ["sh", "-c", "sleep 1 && while [ ! -f /shared/bootstrapped ]; do echo Waiting for bootstrap; sleep 1; done; peer node start --peer-defaultchain=false"]
         env:
         - name: CORE_PEER_ADDRESSAUTODETECT
@@ -264,7 +264,7 @@ spec:
 
       containers:
       - name: org2peer1
-        image: ibmblockchain/fabric-peer:1.0.1
+        image: ibmblockchain/fabric-peer:1.0.3
         command: ["sh", "-c", "sleep 1 && while [ ! -f /shared/bootstrapped ]; do echo Waiting for bootstrap; sleep 1; done;  peer node start --peer-defaultchain=false"]
         env:
         - name: CORE_PEER_ADDRESSAUTODETECT
@@ -345,7 +345,7 @@ spec:
     spec:
       containers:
       - name: couchdb1
-        image: ibmblockchain/fabric-couchdb:1.0.1
+        image: ibmblockchain/fabric-couchdb:1.0.3
         env:
         - name: DB_URL
           value: http://localhost:5984/member_db
@@ -364,7 +364,7 @@ spec:
     spec:
       containers:
       - name: couchdb2
-        image: ibmblockchain/fabric-couchdb:1.0.1
+        image: ibmblockchain/fabric-couchdb:1.0.3
         env:
         - name: DB_URL
           value: http://localhost:5984/member_db

--- a/cs-offerings/kube-configs/blockchain-services-free.yaml
+++ b/cs-offerings/kube-configs/blockchain-services-free.yaml
@@ -11,9 +11,9 @@ spec:
     name: ca
   ports:
   - protocol: TCP
-    nodePort: 30000
+    nodePort: 30054
     targetPort: 7054
-    port: 30000
+    port: 30054
     name: grpc
 ---
 apiVersion: v1

--- a/cs-offerings/kube-configs/blockchain-services-paid.yaml
+++ b/cs-offerings/kube-configs/blockchain-services-paid.yaml
@@ -13,9 +13,9 @@ spec:
     name: ca
   ports:
   - protocol: TCP
-    nodePort: 30000
+    nodePort: 30054
     targetPort: 7054
-    port: 30000
+    port: 30054
     name: grpc
 ---
 apiVersion: v1

--- a/cs-offerings/kube-configs/blockchain.yaml
+++ b/cs-offerings/kube-configs/blockchain.yaml
@@ -48,11 +48,11 @@ spec:
   - name: bootstrap
     image: ibmblockchain/fabric-tools:1.0.3
     imagePullPolicy: Always
-    command: ["sh", "-c", "sleep 1 && while [ ! -f /shared/status_configtxgen_complete ]; do echo Waiting for configtxgen; sleep 1; done && cp -r /sampleconfig/cas /shared && touch /shared/bootstrapped && rm /shared/status_configtxgen_complete && mkdir -p /home/composer && chown 100 /home/composer && echo 'Done with bootstrapping'" ]
+    command: ["sh", "-c", "sleep 1 && while [ ! -f /shared/status_configtxgen_complete ]; do echo Waiting for configtxgen; sleep 1; done && cp -r /sampleconfig/cas /shared && touch /shared/bootstrapped && rm /shared/status_configtxgen_complete && mkdir -p /home/composer/.hfc-key-store && chown 100 /home/composer/.hfc-key-store && echo 'Done with bootstrapping'" ]
     volumeMounts:
     - mountPath: /shared
       name: shared
-    - mountPath: /home
+    - mountPath: /home/composer/.hfc-key-store
       name: composer-credentials
 ---
 apiVersion: extensions/v1beta1

--- a/cs-offerings/kube-configs/composer-identity-import.yaml
+++ b/cs-offerings/kube-configs/composer-identity-import.yaml
@@ -14,7 +14,7 @@ spec:
       claimName: shared-pvc
   containers:
   - name: composer-identity-import
-    image: hyperledger/composer-cli:0.13.2
+    image: hyperledger/composer-cli
     imagePullPolicy: Always
     command: ["sh", "-c", "composer identity import -p hlfv1 -u PeerAdmin -c /shared/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem -k /shared/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/key.pem"]
     env:
@@ -55,7 +55,7 @@ spec:
         }
     volumeMounts:
     - name: composer-credentials
-      mountPath: /home
+      mountPath: /home/composer/.hfc-key-store
     - name: shared
       mountPath: /shared
-      
+

--- a/cs-offerings/kube-configs/composer-identity-import.yaml
+++ b/cs-offerings/kube-configs/composer-identity-import.yaml
@@ -31,7 +31,7 @@ spec:
                   }
               ],
               "ca": {
-                  "url": "http://blockchain-ca:30000",
+                  "url": "http://blockchain-ca:30054",
                   "name": "CA1"
               },
               "peers": [

--- a/cs-offerings/kube-configs/composer-playground.yaml
+++ b/cs-offerings/kube-configs/composer-playground.yaml
@@ -42,7 +42,7 @@ spec:
                       }
                   ],
                   "ca": {
-                      "url": "http://blockchain-ca:30000",
+                      "url": "http://blockchain-ca:30054",
                       "name": "CA1"
                   },
                   "peers": [

--- a/cs-offerings/kube-configs/composer-playground.yaml
+++ b/cs-offerings/kube-configs/composer-playground.yaml
@@ -16,7 +16,7 @@ spec:
           claimName: composer-pvc
       containers:
       - name: composer-playground
-        image: hyperledger/composer-playground:0.13.2
+        image: hyperledger/composer-playground
         imagePullPolicy: Always
         env:
         - name: COMPOSER_CONFIG
@@ -61,4 +61,4 @@ spec:
             }
         volumeMounts:
         - name: composer-credentials
-          mountPath: /home
+          mountPath: /home/composer/.hfc-key-store

--- a/cs-offerings/kube-configs/composer-rest-server.yaml.base
+++ b/cs-offerings/kube-configs/composer-rest-server.yaml.base
@@ -10,9 +10,13 @@ spec:
       labels:
         name: composer-rest-server
     spec:
+      volumes:
+      - name: composer-credentials
+        persistentVolumeClaim:
+          claimName: composer-pvc
       containers:
       - name: composer-rest-server
-        image: hyperledger/composer-rest-server:0.13.2
+        image: hyperledger/composer-rest-server
         imagePullPolicy: Always
         env:
         - name: COMPOSER_CONFIG
@@ -60,3 +64,6 @@ spec:
           value: adminpw
         - name: COMPOSER_NAMESPACES
           value: never
+        volumeMounts:
+        - name: composer-credentials
+          mountPath: /home/composer/.hfc-key-store

--- a/cs-offerings/kube-configs/composer-rest-server.yaml.base
+++ b/cs-offerings/kube-configs/composer-rest-server.yaml.base
@@ -28,7 +28,7 @@ spec:
                       }
                   ],
                   "ca": {
-                      "url": "http://blockchain-ca:30000",
+                      "url": "http://blockchain-ca:30054",
                       "name": "CA1"
                   },
                   "peers": [

--- a/cs-offerings/scripts/connection-profile/connection-profile-org1.json.tmpl
+++ b/cs-offerings/scripts/connection-profile/connection-profile-org1.json.tmpl
@@ -55,7 +55,7 @@
 	},
 	"certificateAuthorities": {
 		"blockchain-ca": {
-			"url": "http://CA-PUBLICIP:30000",
+			"url": "http://CA-PUBLICIP:30054",
 			"httpOptions": {
 				"verify": true
 			},

--- a/cs-offerings/scripts/connection-profile/connection-profile-org2.json.tmpl
+++ b/cs-offerings/scripts/connection-profile/connection-profile-org2.json.tmpl
@@ -55,7 +55,7 @@
 	},
 	"certificateAuthorities": {
 		"blockchain-ca": {
-			"url": "http://CA-PUBLICIP:30000",
+			"url": "http://CA-PUBLICIP:30054",
 			"httpOptions": {
 				"verify": true
 			},

--- a/helm-charts/ibm-blockchain-composer/templates/composer-identity-import.yaml
+++ b/helm-charts/ibm-blockchain-composer/templates/composer-identity-import.yaml
@@ -31,7 +31,7 @@ spec:
                   }
               ],
               "ca": {
-                  "url": "http://blockchain-ca:30000",
+                  "url": "http://blockchain-ca:30054",
                   "name": "CA1"
               },
               "peers": [

--- a/helm-charts/ibm-blockchain-composer/templates/composer-identity-import.yaml
+++ b/helm-charts/ibm-blockchain-composer/templates/composer-identity-import.yaml
@@ -14,7 +14,7 @@ spec:
       claimName: composer-pvc
   containers:
   - name: composer-identity-import
-    image: hyperledger/composer-cli:0.13.2
+    image: hyperledger/composer-cli
     imagePullPolicy: {{.Values.blockchain.pullPolicy}}
     command: ["sh", "-c", "while [ ! -f /shared/status_chaincodeinstantiate_complete ]; do echo Waiting for chaincodeinstantiate; sleep 2; done; composer identity import -p hlfv1 -u PeerAdmin -c /shared/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem -k /shared/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/key.pem"]
     env:
@@ -55,7 +55,7 @@ spec:
         }
     volumeMounts:
     - name: composer-credentials
-      mountPath: /home
+      mountPath: /home/composer/.hfc-key-store
     - name: shared
       mountPath: /shared
-      
+

--- a/helm-charts/ibm-blockchain-composer/templates/composer-playground.yaml
+++ b/helm-charts/ibm-blockchain-composer/templates/composer-playground.yaml
@@ -19,7 +19,7 @@ spec:
           claimName: composer-pvc
       containers:
       - name: composer-playground
-        image: hyperledger/composer-playground:0.13.2
+        image: hyperledger/composer-playground
         imagePullPolicy: {{.Values.blockchain.pullPolicy}}
         env:
         - name: COMPOSER_CONFIG
@@ -59,4 +59,4 @@ spec:
             }
         volumeMounts:
         - name: composer-credentials
-          mountPath: /home
+          mountPath: /home/composer/.hfc-key-store

--- a/helm-charts/ibm-blockchain-composer/templates/composer-playground.yaml
+++ b/helm-charts/ibm-blockchain-composer/templates/composer-playground.yaml
@@ -35,7 +35,7 @@ spec:
                       }
                   ],
                   "ca": {
-                      "url": "http://blockchain-ca:30000",
+                      "url": "http://blockchain-ca:30054",
                       "name": "CA1"
                   },
                   "peers": [

--- a/helm-charts/ibm-blockchain-composer/templates/composer-rest-server.yaml
+++ b/helm-charts/ibm-blockchain-composer/templates/composer-rest-server.yaml
@@ -10,9 +10,13 @@ spec:
       labels:
         name: composer-rest-server
     spec:
+      volumes:
+      - name: composer-credentials
+        persistentVolumeClaim:
+          claimName: composer-pvc
       containers:
       - name: composer-rest-server
-        image: hyperledger/composer-rest-server:0.13.2
+        image: hyperledger/composer-rest-server
         imagePullPolicy: {{.Values.blockchain.pullPolicy}}
         env:
         - name: COMPOSER_CONFIG
@@ -60,3 +64,6 @@ spec:
           value: adminpw
         - name: COMPOSER_NAMESPACES
           value: never
+        volumeMounts:
+        - name: composer-credentials
+          mountPath: /home/composer/.hfc-key-store

--- a/helm-charts/ibm-blockchain-composer/templates/composer-rest-server.yaml
+++ b/helm-charts/ibm-blockchain-composer/templates/composer-rest-server.yaml
@@ -28,7 +28,7 @@ spec:
                       }
                   ],
                   "ca": {
-                      "url": "http://blockchain-ca:30000",
+                      "url": "http://blockchain-ca:30054",
                       "name": "CA1"
                   },
                   "peers": [

--- a/helm-charts/ibm-blockchain-network/templates/blockchain-services.yaml
+++ b/helm-charts/ibm-blockchain-network/templates/blockchain-services.yaml
@@ -12,7 +12,7 @@ spec:
   ports:
   - protocol: TCP
     port: 7054
-    nodePort: 30000
+    nodePort: 30054
     name: grpc
 ---
 apiVersion: v1

--- a/helm-charts/ibm-blockchain-network/templates/blockchain.yaml
+++ b/helm-charts/ibm-blockchain-network/templates/blockchain.yaml
@@ -48,11 +48,11 @@ spec:
   - name: bootstrap
     image: ibmblockchain/fabric-tools:1.0.3
     imagePullPolicy: {{.Values.blockchain.pullPolicy}}
-    command: ["sh", "-c", "sleep 1 && echo \"Starting bootstrap\" && while [ ! -f /shared/status_configtxgen_complete ]; do echo Waiting for configtxgen; sleep 1; done && echo \"Starting bootstrap\" && cp -r /sampleconfig/cas /shared && echo \"Done copying\"  && touch /shared/bootstrapped && rm /shared/status_configtxgen_complete && mkdir -p /home/composer && chown 100 /home/composer && echo 'Done with bootstrapping'" ]
+    command: ["sh", "-c", "sleep 1 && echo \"Starting bootstrap\" && while [ ! -f /shared/status_configtxgen_complete ]; do echo Waiting for configtxgen; sleep 1; done && echo \"Starting bootstrap\" && cp -r /sampleconfig/cas /shared && echo \"Done copying\"  && touch /shared/bootstrapped && rm /shared/status_configtxgen_complete && mkdir -p /home/composer/.hfc-key-store && chown 100 /home/composer/.hfc-key-store && echo 'Done with bootstrapping'" ]
     volumeMounts:
     - mountPath: /shared
       name: shared
-    - mountPath: /home
+    - mountPath: /home/composer/.hfc-key-store
       name: composer-credentials
 ---
 apiVersion: extensions/v1beta1


### PR DESCRIPTION
We pinned the IBM Container Service scripts to Hyperledger Composer v0.13.2 when we introduced the breaking business network administrator changes. We did this so that we could avoid fixing the scripts which broke at the time, but now we need to fix them.

Changes are as follows:

- Change the Fabric CA port to 30054 so the scripts work with minikube
- Update the CouchDB scripts to use Fabric v1.0.3 to avoid cryptogen timing bug
- Get all Composer containers to use a single, shared credential store on a shared volume
- Use latest Composer images

Documentation changes are in another pull request:
https://github.com/IBM-Blockchain/ibm-blockchain.github.io/pull/54