### PR TITLE
add dynamic provisioning option for helm charts

### DIFF
--- a/helm-charts/deploy_charts.sh
+++ b/helm-charts/deploy_charts.sh
@@ -32,17 +32,20 @@ function cleanEnvironment() {
         helm delete --purge ${HELM_RELEASES}
     fi
 
-    # Wipe the /shared persistent volume
-    kubectl create -f ../cs-offerings/kube-configs/wipe_shared.yaml
+    # Wipe the /shared persistent volume if it exists (it should be removed with chart removal)
+    kubectl get pv shared > /dev/null 2>&1
+    if [[ $? -eq 0 ]]; then
+        kubectl create -f ../cs-offerings/kube-configs/wipe_shared.yaml
 
-    # Wait for the wipe shared pod to finish
-    while [ "$(kubectl get pod -a wipeshared | grep wipeshared | awk '{print $3}')" != "Completed" ]; do
-        echo "Waiting for the shared folder to be erased..."
-        sleep 1;
-    done
+        # Wait for the wipe shared pod to finish
+        while [ "$(kubectl get pod -a wipeshared | grep wipeshared | awk '{print $3}')" != "Completed" ]; do
+            echo "Waiting for the shared folder to be erased..."
+            sleep 1;
+        done
 
-    # Delete the wipe shared pod
-    kubectl delete -f ../cs-offerings/kube-configs/wipe_shared.yaml
+        # Delete the wipe shared pod
+        kubectl delete -f ../cs-offerings/kube-configs/wipe_shared.yaml
+    fi
 }
 
 #

--- a/helm-charts/ibm-blockchain-network/README.md
+++ b/helm-charts/ibm-blockchain-network/README.md
@@ -45,6 +45,7 @@ The following tables lists the configurable parameters of the IBM Blockchain cha
 |             Parameter              |               Description                |                         Default                          |
 |------------------------------------|------------------------------------------|----------------------------------------------------------|
 | `blockchain.pullPolicy`            | Blockchain image pull policy             | `Always`                                                 |
+| `persistence.storageClass`  | Storage Class for dynamic provisioning | nil |
 
 
 The above parameters map to the env variables defined in [IBM-Blockchain/ibm-container-service](https://github.ibm.com/IBM-Blockchain/ibm-container-service). For more information please refer to the [IBM-Blockchain/ibm-container-service](https://github.ibm.com/IBM-Blockchain/ibm-container-service) documentation.

--- a/helm-charts/ibm-blockchain-network/templates/composer-pvc.yaml
+++ b/helm-charts/ibm-blockchain-network/templates/composer-pvc.yaml
@@ -2,7 +2,7 @@
 kind: PersistentVolume
 apiVersion: v1
 metadata:
-  name: shared
+  name: composer-pvc
   labels:
     type: local
 spec:
@@ -11,13 +11,13 @@ spec:
   accessModes:
     - ReadWriteMany
   hostPath:
-    path: "/tmp"
+    path: "/composer"
 {{- end }}
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: shared
+  name: composer-pvc
 {{- if .Values.persistence.storageClass }}
   annotations:
     volume.beta.kubernetes.io/storage-class: "{{ .Values.persistence.storageClass }}"

--- a/helm-charts/ibm-blockchain-network/values.yaml
+++ b/helm-charts/ibm-blockchain-network/values.yaml
@@ -36,5 +36,10 @@ resources: {}
   #  cpu: 100m
   #  memory: 128Mi
 
-blockchain: 
+persistence:
+  # If set to "", disables dynamic provisioning and create persistent volumes specified
+  # from the templates. If set, use the defined storage class and do not create pvs.
+  storageClass: ""
+
+blockchain:
   pullPolicy: Always


### PR DESCRIPTION
Add item for persistence.storageClass to support dynamic volume provisioning for shared and composer pvcs to `helm-charts/ibm-blockchain-network/values.yaml` . Default behavior kept to use hostPath persistent volumes. 

Change logic in `deploy_charts.sh` to avoid blocking when the `/shared` persistent volume is removed after helm charts are removed or when it has not yet been created (first run of script).

PR allows for deployment to clusters with more than one worker supporting a dynamic volume provisioner for persistence. Tested on IBM Cloud Private using an nfs-based dynamic provisioner https://github.com/timroster/deploy-ibm-cloud-private/blob/all_features/docs/deploy-nfs-provisioner.md . 