### PR TITLE
hold chaincode instantiate for both org peers

### DIFF
--- a/helm-charts/ibm-blockchain-chaincode/templates/chaincode_install_org1peer1.yaml
+++ b/helm-charts/ibm-blockchain-chaincode/templates/chaincode_install_org1peer1.yaml
@@ -14,7 +14,7 @@ spec:
   - name: chaincodeinstall-org1peer1
     image: ibmblockchain/fabric-tools:1.0.1
     imagePullPolicy: {{.Values.blockchain.pullPolicy}}
-    command: ["sh", "-c", "while [ ! -f /shared/status_joinchannel_org1peer1_complete ]; do echo Waiting for joinchannel; sleep 2; done; git clone -b v1.0.1 https://github.com/hyperledger/fabric $GOPATH/src/github.com/hyperledger/fabric/ && peer chaincode install -n ${CHAINCODE_NAME} -v ${CHAINCODE_VERSION} -p github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02/ && touch /shared/status_chaincodeinstall_complete"]
+    command: ["sh", "-c", "while [ ! -f /shared/status_joinchannel_org1peer1_complete ]; do echo Waiting for joinchannel; sleep 2; done; git clone -b v1.0.1 https://github.com/hyperledger/fabric $GOPATH/src/github.com/hyperledger/fabric/ && peer chaincode install -n ${CHAINCODE_NAME} -v ${CHAINCODE_VERSION} -p github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02/ && touch /shared/status_chaincodeinstall_o1p1_complete"]
     env:
     - name: CHAINCODE_NAME
       value: example02

--- a/helm-charts/ibm-blockchain-chaincode/templates/chaincode_install_org2peer1.yaml
+++ b/helm-charts/ibm-blockchain-chaincode/templates/chaincode_install_org2peer1.yaml
@@ -14,7 +14,7 @@ spec:
   - name: chaincodeinstall-org2peer1
     image: ibmblockchain/fabric-tools:1.0.1
     imagePullPolicy: {{.Values.blockchain.pullPolicy}}
-    command: ["sh", "-c", "while [ ! -f /shared/status_joinchannel_org2peer1_complete ]; do echo Waiting for joinchannel; sleep 2; done; git clone -b v1.0.1 https://github.com/hyperledger/fabric $GOPATH/src/github.com/hyperledger/fabric/ && peer chaincode install -n ${CHAINCODE_NAME} -v ${CHAINCODE_VERSION} -p github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02/ && touch /shared/status_chaincodeinstall_complete"]
+    command: ["sh", "-c", "while [ ! -f /shared/status_joinchannel_org2peer1_complete ]; do echo Waiting for joinchannel; sleep 2; done; git clone -b v1.0.1 https://github.com/hyperledger/fabric $GOPATH/src/github.com/hyperledger/fabric/ && peer chaincode install -n ${CHAINCODE_NAME} -v ${CHAINCODE_VERSION} -p github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02/ && touch /shared/status_chaincodeinstall_o2p1_complete"]
     env:
     - name: CHAINCODE_NAME
       value: example02

--- a/helm-charts/ibm-blockchain-chaincode/templates/chaincode_instantiate.yaml
+++ b/helm-charts/ibm-blockchain-chaincode/templates/chaincode_instantiate.yaml
@@ -14,7 +14,7 @@ spec:
   - name: chaincodeinstantiate
     image: ibmblockchain/fabric-tools:1.0.1
     imagePullPolicy: {{.Values.blockchain.pullPolicy}}
-    command: ["sh", "-c", "while [ ! -f /shared/status_chaincodeinstall_complete ]; do echo Waiting for chaincodeinstall; sleep 2; done; peer chaincode instantiate -o blockchain-orderer:31010 -C ${CHANNEL_NAME} -n ${CHAINCODE_NAME} -v ${CHAINCODE_VERSION} -c '{\"Args\":[\"init\",\"a\",\"100\",\"b\",\"200\"]}' && touch /shared/status_chaincodeinstantiate_complete && rm -f /shared/status_chaincodeinstall_complete"]
+    command: ["sh", "-c", "while [ ! -f /shared/status_chaincodeinstall_o1p1_complete ] || [ ! -f /shared/status_chaincodeinstall_o2p1_complete ]; do echo Waiting for chaincodeinstall; sleep 2; done; peer chaincode instantiate -o blockchain-orderer:31010 -C ${CHANNEL_NAME} -n ${CHAINCODE_NAME} -v ${CHAINCODE_VERSION} -c '{\"Args\":[\"init\",\"a\",\"100\",\"b\",\"200\"]}' && touch /shared/status_chaincodeinstantiate_complete && rm -f /shared/status_chaincodeinstall_*_complete"]
     env:
     - name: CHANNEL_NAME
       value: {{.Values.blockchain.channelName}}


### PR DESCRIPTION
Change logic in command run by chaincodeinstantiate pod to confirm both org1peer1 and org2peer1 have completed chaincode install before continuing with chaincode instantiation.

Addresses #55 