### PR TITLE
changing the storage host path from /tmp to /network

### DIFF
--- a/cs-offerings/kube-configs/storage-free.yaml
+++ b/cs-offerings/kube-configs/storage-free.yaml
@@ -12,7 +12,7 @@ spec:
   accessModes:
     - ReadWriteMany
   hostPath:
-    path: "/tmp"
+    path: "/network"
 
 ---
 kind: PersistentVolume


### PR DESCRIPTION
fixes #66 

- test: Started a free network, rebooted the worker, checked orderer and peer logs.