### PR TITLE
Adding mounts for orderer and peer

### DIFF
--- a/cs-offerings/kube-configs/blockchain-couchdb.yaml
+++ b/cs-offerings/kube-configs/blockchain-couchdb.yaml
@@ -70,11 +70,11 @@ spec:
       - name: shared
         persistentVolumeClaim:
           claimName: shared-pvc
+      - name: ledger
+        persistentVolumeClaim:
+          claimName: ledger-pvc
 
       containers:
-      - name: pulse
-        image: ibmblockchain/fabric-tools:1.0.3
-        command: ["sh", "-c", "sleep 1 && UUID=$(cat /proc/sys/kernel/random/uuid) && while [ true ]; do curl https://ics-endpoint.mybluemix.net/pulse/beat/$UUID; sleep 10; done"]
       - name: orderer
         image: ibmblockchain/fabric-orderer:1.0.3
         command: ["sh", "-c", "sleep 5 && while [ ! -f /shared/bootstrapped ]; do echo Waiting for bootstrap; sleep 1; done; orderer"]
@@ -84,7 +84,7 @@ spec:
         - name: ORDERER_GENERAL_LEDGERTYPE
           value: file
         - name: ORDERER_FILELEDGER_LOCATION
-          value: /mnt/ledger/orderer1
+          value: /ledger/orderer/fileledger
         - name: ORDERER_GENERAL_BATCHTIMEOUT
           value: 1s
         - name: ORDERER_GENERAL_BATCHSIZE_MAXMESSAGECOUNT
@@ -116,6 +116,11 @@ spec:
         volumeMounts:
         - mountPath: /shared
           name: shared
+        - mountPath: /ledger
+          name: ledger
+      - name: pulse
+        image: ibmblockchain/fabric-tools:1.0.3
+        command: ["sh", "-c", "sleep 1 && UUID=$(cat /proc/sys/kernel/random/uuid) && while [ true ]; do curl https://ics-endpoint.mybluemix.net/pulse/beat/$UUID; sleep 10; done"]
 
 ---
 apiVersion: extensions/v1beta1
@@ -175,6 +180,9 @@ spec:
       - name: shared
         persistentVolumeClaim:
           claimName: shared-pvc
+      - name: ledger
+        persistentVolumeClaim:
+          claimName: ledger-pvc
       - name: dockersocket
         hostPath:
           path: /var/run/docker.sock
@@ -186,10 +194,10 @@ spec:
         env:
         - name: CORE_PEER_ADDRESSAUTODETECT
           value: "true"
-        - name: CORE_PEER_ID
-          value: org1peer1
         - name: CORE_PEER_NETWORKID
           value: nid1
+        - name: CORE_PEER_ID
+          value: org1peer1
         - name: CORE_PEER_ADDRESS
           value: blockchain-org1peer1:30110
         - name: CORE_PEER_LISTENADDRESS
@@ -234,6 +242,8 @@ spec:
           value: CouchDB
         - name: CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS
           value: blockchain-couchdb1:30984
+        - name: CORE_PEER_FILESYSTEMPATH
+          value: /ledger/org1/peer1/ledger
         - name: FABRIC_CFG_PATH
           value: /etc/hyperledger/fabric/
         - name: ORDERER_URL
@@ -245,6 +255,8 @@ spec:
         volumeMounts:
         - mountPath: /shared
           name: shared
+        - mountPath: /ledger
+          name: ledger
         - mountPath: /host/var/run/docker.sock
           name: dockersocket
 ---
@@ -263,6 +275,9 @@ spec:
       - name: shared
         persistentVolumeClaim:
           claimName: shared-pvc
+      - name: ledger
+        persistentVolumeClaim:
+          claimName: ledger-pvc
       - name: dockersocket
         hostPath:
           path: /var/run/docker.sock
@@ -300,6 +315,8 @@ spec:
           value: Org2MSP
         - name: CORE_PEER_MSPCONFIGPATH
           value: /shared/crypto-config/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/msp/
+        - name: CORE_PEER_FILESYSTEMPATH
+          value: /ledger/org2/peer1/ledger
         - name: CORE_LOGGING_LEVEL
           value: debug
         - name: CORE_LOGGING_PEER
@@ -333,6 +350,8 @@ spec:
         volumeMounts:
         - mountPath: /shared
           name: shared
+        - mountPath: /ledger
+          name: ledger
         - mountPath: /host/var/run/docker.sock
           name: dockersocket
 

--- a/cs-offerings/kube-configs/blockchain.yaml
+++ b/cs-offerings/kube-configs/blockchain.yaml
@@ -70,11 +70,11 @@ spec:
       - name: shared
         persistentVolumeClaim:
           claimName: shared-pvc
+      - name: ledger
+        persistentVolumeClaim:
+          claimName: ledger-pvc
 
       containers:
-      - name: pulse
-        image: ibmblockchain/fabric-tools:1.0.3
-        command: ["sh", "-c", "sleep 1 && UUID=$(cat /proc/sys/kernel/random/uuid) && while [ true ]; do curl https://ics-endpoint.mybluemix.net/pulse/beat/$UUID; sleep 10; done"]
       - name: orderer
         image: ibmblockchain/fabric-orderer:1.0.3
         command: ["sh", "-c", "sleep 5 && while [ ! -f /shared/bootstrapped ]; do echo Waiting for bootstrap; sleep 1; done; orderer"]
@@ -84,7 +84,7 @@ spec:
         - name: ORDERER_GENERAL_LEDGERTYPE
           value: file
         - name: ORDERER_FILELEDGER_LOCATION
-          value: /mnt/ledger/orderer1
+          value: /ledger/orderer/fileledger
         - name: ORDERER_GENERAL_BATCHTIMEOUT
           value: 1s
         - name: ORDERER_GENERAL_BATCHSIZE_MAXMESSAGECOUNT
@@ -116,7 +116,11 @@ spec:
         volumeMounts:
         - mountPath: /shared
           name: shared
-
+        - mountPath: /ledger
+          name: ledger
+      - name: pulse
+        image: ibmblockchain/fabric-tools:1.0.3
+        command: ["sh", "-c", "sleep 1 && UUID=$(cat /proc/sys/kernel/random/uuid) && while [ true ]; do curl https://ics-endpoint.mybluemix.net/pulse/beat/$UUID; sleep 10; done"]
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -175,6 +179,9 @@ spec:
       - name: shared
         persistentVolumeClaim:
           claimName: shared-pvc
+      - name: ledger
+        persistentVolumeClaim:
+          claimName: ledger-pvc
       - name: dockersocket
         hostPath:
           path: /var/run/docker.sock
@@ -232,6 +239,8 @@ spec:
           value: "false"
         - name: CORE_LEDGER_STATE_STATEDATABASE
           value: goleveldb
+        - name: CORE_PEER_FILESYSTEMPATH
+          value: /ledger/org1/peer1/ledger
         - name: FABRIC_CFG_PATH
           value: /etc/hyperledger/fabric/
         - name: ORDERER_URL
@@ -243,6 +252,8 @@ spec:
         volumeMounts:
         - mountPath: /shared
           name: shared
+        - mountPath: /ledger
+          name: ledger
         - mountPath: /host/var/run/docker.sock
           name: dockersocket
 ---
@@ -261,6 +272,9 @@ spec:
       - name: shared
         persistentVolumeClaim:
           claimName: shared-pvc
+      - name: ledger
+        persistentVolumeClaim:
+          claimName: ledger-pvc
       - name: dockersocket
         hostPath:
           path: /var/run/docker.sock
@@ -298,6 +312,8 @@ spec:
           value: Org2MSP
         - name: CORE_PEER_MSPCONFIGPATH
           value: /shared/crypto-config/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/msp/
+        - name: CORE_PEER_FILESYSTEMPATH
+          value: /ledger/org2/peer1/ledger
         - name: CORE_LOGGING_LEVEL
           value: debug
         - name: CORE_LOGGING_PEER
@@ -329,5 +345,7 @@ spec:
         volumeMounts:
         - mountPath: /shared
           name: shared
+        - mountPath: /ledger
+          name: ledger
         - mountPath: /host/var/run/docker.sock
           name: dockersocket

--- a/cs-offerings/kube-configs/storage-free.yaml
+++ b/cs-offerings/kube-configs/storage-free.yaml
@@ -31,6 +31,22 @@ spec:
     path: "/composer"
 
 ---
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: ledger-pv
+  labels:
+    type: local
+    name: ledger
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteMany
+  hostPath:
+    path: "/ledger"
+
+---
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
@@ -44,6 +60,7 @@ spec:
   selector:
     matchLabels:
       name: shared
+
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
@@ -58,3 +75,18 @@ spec:
   selector:
     matchLabels:
       name: composer
+
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: ledger-pvc
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Gi
+  selector:
+    matchLabels:
+      name: ledger

--- a/cs-offerings/kube-configs/storage-paid.yaml
+++ b/cs-offerings/kube-configs/storage-paid.yaml
@@ -31,3 +31,20 @@ spec:
   resources:
     requests:
       storage: 20Gi
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ledger-pvc
+  annotations:
+    #ibmc-file-bronze: 2 IOPS per GB.
+    #ibmc-file-silver: 4 IOPS per GB.
+    #ibmc-file-gold: 10 IOPS per GB.
+    volume.beta.kubernetes.io/storage-class: "ibmc-file-silver"
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 20Gi


### PR DESCRIPTION
- This will fix part of #61. 
- This PR adds mount points for ledger on orderer and peer. For this a new PVC has been added to the storage-yaml's and then mounted appropriately.

For the fix to work, the users must delete all old storages:
`./delete_all.sh -i` will do this.

And then run 
`./create_all.sh` to create the new storages.