### PR TITLE
update to remove -a option from kubectl get pod and kubectl get pods.

### DIFF
--- a/cs-offerings/scripts/create/chaincode_install.sh
+++ b/cs-offerings/scripts/create/chaincode_install.sh
@@ -60,15 +60,15 @@ echo "Creating chaincodeinstall pod"
 echo "Running: kubectl create -f ${KUBECONFIG_FOLDER}/chaincode_install.yaml"
 kubectl create -f ${KUBECONFIG_FOLDER}/chaincode_install.yaml
 
-while [ "$(kubectl get pod -a chaincodeinstall | grep chaincodeinstall | awk '{print $3}')" != "Completed" ]; do
+while [ "$(kubectl get pod chaincodeinstall | grep chaincodeinstall | awk '{print $3}')" != "Completed" ]; do
     echo "Waiting for chaincodeinstall container to be Completed"
     sleep 1;
 done
 
-if [ "$(kubectl get pod -a chaincodeinstall | grep chaincodeinstall | awk '{print $3}')" == "Completed" ]; then
+if [ "$(kubectl get pod chaincodeinstall | grep chaincodeinstall | awk '{print $3}')" == "Completed" ]; then
 	echo "Install Chaincode Completed Successfully"
 fi
 
-if [ "$(kubectl get pod -a chaincodeinstall | grep chaincodeinstall | awk '{print $3}')" != "Completed" ]; then
+if [ "$(kubectl get pod chaincodeinstall | grep chaincodeinstall | awk '{print $3}')" != "Completed" ]; then
 	echo "Install Chaincode Failed"
 fi

--- a/cs-offerings/scripts/create/chaincode_instantiate.sh
+++ b/cs-offerings/scripts/create/chaincode_instantiate.sh
@@ -68,15 +68,15 @@ echo "Creating chaincodeinstantiate pod"
 echo "Running: kubectl create -f ${KUBECONFIG_FOLDER}/chaincode_instantiate.yaml"
 kubectl create -f ${KUBECONFIG_FOLDER}/chaincode_instantiate.yaml
 
-while [ "$(kubectl get pod -a chaincodeinstantiate | grep chaincodeinstantiate | awk '{print $3}')" != "Completed" ]; do
+while [ "$(kubectl get pod chaincodeinstantiate | grep chaincodeinstantiate | awk '{print $3}')" != "Completed" ]; do
     echo "Waiting for chaincodeinstantiate container to be Completed"
     sleep 1;
 done
 
-if [ "$(kubectl get pod -a chaincodeinstantiate | grep chaincodeinstantiate | awk '{print $3}')" == "Completed" ]; then
+if [ "$(kubectl get pod chaincodeinstantiate | grep chaincodeinstantiate | awk '{print $3}')" == "Completed" ]; then
 	echo "Instantiate Chaincode Completed Successfully"
 fi
 
-if [ "$(kubectl get pod -a chaincodeinstantiate | grep chaincodeinstantiate | awk '{print $3}')" != "Completed" ]; then
+if [ "$(kubectl get pod chaincodeinstantiate | grep chaincodeinstantiate | awk '{print $3}')" != "Completed" ]; then
 	echo "Instantiate Chaincode Failed"
 fi

--- a/cs-offerings/scripts/create/create_blockchain.sh
+++ b/cs-offerings/scripts/create/create_blockchain.sh
@@ -65,28 +65,28 @@ while [ "${NUMPENDING}" != "0" ]; do
     sleep 1
 done
 
-UTILSSTATUS=$(kubectl get pods -a utils | grep utils | awk '{print $3}')
+UTILSSTATUS=$(kubectl get pods utils | grep utils | awk '{print $3}')
 while [ "${UTILSSTATUS}" != "Completed" ]; do
     echo "Waiting for Utils pod to start completion. Status = ${UTILSSTATUS}"
     if [ "${UTILSSTATUS}" == "Error" ]; then
         echo "There is an error in utils pod. Please run 'kubectl logs utils' or 'kubectl describe pod utils'."
         exit 1
     fi
-    UTILSSTATUS=$(kubectl get pods -a utils | grep utils | awk '{print $3}')
+    UTILSSTATUS=$(kubectl get pods utils | grep utils | awk '{print $3}')
 done
 
 
-UTILSCOUNT=$(kubectl get pods -a utils | grep "0/3" | grep "Completed" | wc -l | awk '{print $1}')
+UTILSCOUNT=$(kubectl get pods utils | grep "0/3" | grep "Completed" | wc -l | awk '{print $1}')
 while [ "${UTILSCOUNT}" != "1" ]; do
-    UTILSLEFT=$(kubectl get pods -a utils | grep utils | awk '{print $2}')
+    UTILSLEFT=$(kubectl get pods utils | grep utils | awk '{print $2}')
     echo "Waiting for all containers in Utils pod to complete. Left = ${UTILSLEFT}"
-    UTILSSTATUS=$(kubectl get pods -a utils | grep utils | awk '{print $3}')
+    UTILSSTATUS=$(kubectl get pods utils | grep utils | awk '{print $3}')
     if [ "${UTILSSTATUS}" == "Error" ]; then
         echo "There is an error in utils pod. Please run 'kubectl logs utils' or 'kubectl describe pod utils'."
         exit 1
     fi
     sleep 1
-    UTILSCOUNT=$(kubectl get pods -a utils | grep "0/3" | grep "Completed" | wc -l | awk '{print $1}')
+    UTILSCOUNT=$(kubectl get pods utils | grep "0/3" | grep "Completed" | wc -l | awk '{print $1}')
 done
 
 echo "Waiting for 15 seconds for peers and orderer to settle"

--- a/cs-offerings/scripts/create/create_channel.sh
+++ b/cs-offerings/scripts/create/create_channel.sh
@@ -35,15 +35,15 @@ echo "Creating createchannel pod"
 echo "Running: kubectl create -f ${KUBECONFIG_FOLDER}/create_channel.yaml"
 kubectl create -f ${KUBECONFIG_FOLDER}/create_channel.yaml
 
-while [ "$(kubectl get pod -a createchannel | grep createchannel | awk '{print $3}')" != "Completed" ]; do
+while [ "$(kubectl get pod createchannel | grep createchannel | awk '{print $3}')" != "Completed" ]; do
     echo "Waiting for createchannel container to be Completed"
     sleep 1;
 done
 
-if [ "$(kubectl get pod -a createchannel | grep createchannel | awk '{print $3}')" == "Completed" ]; then
+if [ "$(kubectl get pod createchannel | grep createchannel | awk '{print $3}')" == "Completed" ]; then
 	echo "Create Channel Completed Successfully"
 fi
 
-if [ "$(kubectl get pod -a createchannel | grep createchannel | awk '{print $3}')" != "Completed" ]; then
+if [ "$(kubectl get pod createchannel | grep createchannel | awk '{print $3}')" != "Completed" ]; then
 	echo "Create Channel Failed"
 fi

--- a/cs-offerings/scripts/create/create_composer-playground.sh
+++ b/cs-offerings/scripts/create/create_composer-playground.sh
@@ -34,16 +34,16 @@ echo "Creating composer-card-import pod"
 echo "Running: kubectl create -f ${KUBECONFIG_FOLDER}/composer-card-import.yaml"
 kubectl create -f ${KUBECONFIG_FOLDER}/composer-card-import.yaml
 
-while [ "$(kubectl get pod -a composer-card-import | grep composer-card-import | awk '{print $3}')" != "Completed" ]; do
+while [ "$(kubectl get pod composer-card-import | grep composer-card-import | awk '{print $3}')" != "Completed" ]; do
     echo "Waiting for composer-card-import container to be Completed"
     sleep 1;
 done
 
-if [ "$(kubectl get pod -a composer-card-import | grep composer-card-import | awk '{print $3}')" == "Completed" ]; then
+if [ "$(kubectl get pod composer-card-import | grep composer-card-import | awk '{print $3}')" == "Completed" ]; then
 	echo "Composer Card Import Completed Successfully"
 fi
 
-if [ "$(kubectl get pod -a composer-card-import | grep composer-card-import | awk '{print $3}')" != "Completed" ]; then
+if [ "$(kubectl get pod composer-card-import | grep composer-card-import | awk '{print $3}')" != "Completed" ]; then
 	echo "Composer Card Import Failed"
 fi
 

--- a/cs-offerings/scripts/create/join_channel.sh
+++ b/cs-offerings/scripts/create/join_channel.sh
@@ -51,15 +51,15 @@ echo "Creating joinchannel pod"
 echo "Running: kubectl create -f ${KUBECONFIG_FOLDER}/join_channel.yaml"
 kubectl create -f ${KUBECONFIG_FOLDER}/join_channel.yaml
 
-while [ "$(kubectl get pod -a joinchannel | grep joinchannel | awk '{print $3}')" != "Completed" ]; do
+while [ "$(kubectl get pod joinchannel | grep joinchannel | awk '{print $3}')" != "Completed" ]; do
     echo "Waiting for joinchannel container to be Completed"
     sleep 1;
 done
 
-if [ "$(kubectl get pod -a joinchannel | grep joinchannel | awk '{print $3}')" == "Completed" ]; then
+if [ "$(kubectl get pod joinchannel | grep joinchannel | awk '{print $3}')" == "Completed" ]; then
 	echo "Join Channel Completed Successfully"
 fi
 
-if [ "$(kubectl get pod -a joinchannel | grep joinchannel | awk '{print $3}')" != "Completed" ]; then
+if [ "$(kubectl get pod joinchannel | grep joinchannel | awk '{print $3}')" != "Completed" ]; then
 	echo "Join Channel Failed"
 fi

--- a/cs-offerings/scripts/delete/delete_blockchain.sh
+++ b/cs-offerings/scripts/delete/delete_blockchain.sh
@@ -47,7 +47,7 @@ else
 fi
 
 echo "Deleting blockchain deployments"
-if [ "$(kubectl get pods -a | grep couchdb | wc -l | awk '{print $1}')" != "0" ]; then
+if [ "$(kubectl get pods | grep couchdb | wc -l | awk '{print $1}')" != "0" ]; then
     # Use the yaml file with couchdb
     echo "Running: kubectl delete -f ${KUBECONFIG_FOLDER}/blockchain-couchdb.yaml"
     kubectl delete -f ${KUBECONFIG_FOLDER}/blockchain-couchdb.yaml

--- a/cs-offerings/scripts/delete/delete_chaincode-install.sh
+++ b/cs-offerings/scripts/delete/delete_chaincode-install.sh
@@ -21,12 +21,12 @@ echo "Preparing yaml for chaincodeinstall pod"
 sed -e "s/%PEER_ADDRESS%/${PEER_ADDRESS}/g" -e "s/%PEER_MSPID%/${PEER_MSPID}/g" -e "s|%MSP_CONFIGPATH%|${MSP_CONFIGPATH}|g"  -e "s/%CHAINCODE_NAME%/${CHAINCODE_NAME}/g" -e "s/%CHAINCODE_VERSION%/${CHAINCODE_VERSION}/g" ${KUBECONFIG_FOLDER}/chaincode_install.yaml.base > ${KUBECONFIG_FOLDER}/chaincode_install.yaml
 
 echo "Deleting Existing Install Chaincode Pod"
-if [ "$(kubectl get pods -a | grep chaincodeinstall | wc -l | awk '{print $1}')" != "0" ]; then
+if [ "$(kubectl get pods | grep chaincodeinstall | wc -l | awk '{print $1}')" != "0" ]; then
     echo "Running: kubectl delete -f ${KUBECONFIG_FOLDER}/chaincode_install.yaml"
     kubectl delete -f ${KUBECONFIG_FOLDER}/chaincode_install.yaml
 
     # Wait for the pod to be deleted
-    while [ "$(kubectl get pods -a | grep chaincodeinstall | wc -l | awk '{print $1}')" != "0" ]; do
+    while [ "$(kubectl get pods | grep chaincodeinstall | wc -l | awk '{print $1}')" != "0" ]; do
         echo "Waiting for old install chaincode Pod to be deleted"
         sleep 1;
     done

--- a/cs-offerings/scripts/delete/delete_chaincode-instantiate.sh
+++ b/cs-offerings/scripts/delete/delete_chaincode-instantiate.sh
@@ -21,12 +21,12 @@ echo "Preparing yaml for chaincode instantiate delete"
 sed -e "s/%CHANNEL_NAME%/${CHANNEL_NAME}/g" -e "s/%PEER_ADDRESS%/${PEER_ADDRESS}/g" -e "s/%PEER_MSPID%/${PEER_MSPID}/g" -e "s|%MSP_CONFIGPATH%|${MSP_CONFIGPATH}|g"  -e "s/%CHAINCODE_NAME%/${CHAINCODE_NAME}/g" -e "s/%CHAINCODE_VERSION%/${CHAINCODE_VERSION}/g" ${KUBECONFIG_FOLDER}/chaincode_instantiate.yaml.base > ${KUBECONFIG_FOLDER}/chaincode_instantiate.yaml
 
 echo "Deleting Existing Instantiate Chaincode Pod"
-if [ "$(kubectl get pods -a | grep chaincodeinstantiate | wc -l | awk '{print $1}')" != "0" ]; then
+if [ "$(kubectl get pods | grep chaincodeinstantiate | wc -l | awk '{print $1}')" != "0" ]; then
     echo "Running: kubectl delete -f ${KUBECONFIG_FOLDER}/chaincode_instantiate.yaml"
     kubectl delete -f ${KUBECONFIG_FOLDER}/chaincode_instantiate.yaml
 
     # Wait for the pod to be deleted
-    while [ "$(kubectl get pods -a | grep chaincodeinstantiate | wc -l | awk '{print $1}')" != "0" ]; do
+    while [ "$(kubectl get pods | grep chaincodeinstantiate | wc -l | awk '{print $1}')" != "0" ]; do
         echo "Waiting for old instantiate chaincode Pod to be deleted"
         sleep 1;
     done

--- a/cs-offerings/scripts/delete/delete_channel-pods.sh
+++ b/cs-offerings/scripts/delete/delete_channel-pods.sh
@@ -18,12 +18,12 @@ echo "Preparing yaml for createchannel pod for deletion"
 sed -e "s/%PEER_ADDRESS%/${PEER_ADDRESS}/g" -e "s/%CHANNEL_NAME%/${CHANNEL_NAME}/g" -e "s/%PEER_MSPID%/${PEER_MSPID}/g" ${KUBECONFIG_FOLDER}/create_channel.yaml.base > ${KUBECONFIG_FOLDER}/create_channel.yaml
 
 echo "Deleting Existing Create Channel Pod"
-if [ "$(kubectl get pods -a | grep createchannel | wc -l | awk '{print $1}')" != "0" ]; then
+if [ "$(kubectl get pods | grep createchannel | wc -l | awk '{print $1}')" != "0" ]; then
 	echo "Running: kubectl delete -f ${KUBECONFIG_FOLDER}/create_channel.yaml"
     kubectl delete -f ${KUBECONFIG_FOLDER}/create_channel.yaml
 
     # Wait for the pod to be deleted
-    while [ "$(kubectl get pods -a | grep createchannel | wc -l | awk '{print $1}')" != "0" ]; do
+    while [ "$(kubectl get pods | grep createchannel | wc -l | awk '{print $1}')" != "0" ]; do
         echo "Waiting for old Create Channel Pod to be deleted"
         sleep 1;
     done
@@ -37,13 +37,13 @@ fi
 echo "Preparing yaml for joinchannel pod for deletion"
 sed -e "s/%PEER_ADDRESS%/${PEER_ADDRESS}/g" -e "s/%CHANNEL_NAME%/${CHANNEL_NAME}/g" -e "s/%PEER_MSPID%/${PEER_MSPID}/g" -e "s|%MSP_CONFIGPATH%|${MSP_CONFIGPATH}|g" ${KUBECONFIG_FOLDER}/join_channel.yaml.base > ${KUBECONFIG_FOLDER}/join_channel.yaml
 
-if [ "$(kubectl get pods -a | grep joinchannel | wc -l | awk '{print $1}')" != "0" ]; then
+if [ "$(kubectl get pods | grep joinchannel | wc -l | awk '{print $1}')" != "0" ]; then
     echo "Deleting Existing joinchannel pods"
     echo "Running: kubectl delete -f ${KUBECONFIG_FOLDER}/join_channel.yaml"
     kubectl delete -f ${KUBECONFIG_FOLDER}/join_channel.yaml
 
     # Wait for the pod to be deleted
-    while [ "$(kubectl get pods -a | grep joinchannel | wc -l | awk '{print $1}')" != "0" ]; do
+    while [ "$(kubectl get pods | grep joinchannel | wc -l | awk '{print $1}')" != "0" ]; do
         echo "Waiting for old Join Channel to be deleted"
         sleep 1;
     done

--- a/cs-offerings/scripts/wipe_shared.sh
+++ b/cs-offerings/scripts/wipe_shared.sh
@@ -9,7 +9,7 @@ else
 	kubectl create -f ../kube-configs/wipe_shared.yaml	
 fi
 
-while [ "$(kubectl get pod -a wipeshared | grep wipeshared | awk '{print $3}')" != "Completed" ]; do
+while [ "$(kubectl get pod wipeshared | grep wipeshared | awk '{print $3}')" != "Completed" ]; do
     echo "Waiting for the shared folder to be erased"
     sleep 1;
 done


### PR DESCRIPTION
The -a option on ```kubectl get pod``` and ```kubectl get pods``` has been deprecated. Running it with the current version of kubectl on IBM Cloud results in this error message:
```
Flag --show-all has been deprecated, will be removed in an upcoming release
```
This pull request updates the following scripts by removing the -a option
```
cs-offerings/scripts/create/chaincode_install.sh
cs-offerings/scripts/create/chaincode_instantiate.sh
cs-offerings/scripts/create/create_blockchain.sh
cs-offerings/scripts/create/create_channel.sh
cs-offerings/scripts/create/create_composer-playground.sh
cs-offerings/scripts/create/join_channel.sh
cs-offerings/scripts/delete/delete_blockchain.sh
cs-offerings/scripts/delete/delete_chaincode-install.sh
cs-offerings/scripts/delete/delete_chaincode-instantiate.sh
cs-offerings/scripts/delete/delete_channel-pods.sh
cs-offerings/scripts/wipe_shared.sh
```