### PR TITLE
Updated scripts and k8s config files for base ibm fabric 1.1 images

### DIFF
--- a/cs-offerings/kube-configs/blockchain-couchdb.yaml
+++ b/cs-offerings/kube-configs/blockchain-couchdb.yaml
@@ -19,14 +19,14 @@ spec:
   - name: cryptogen
     image: ibmblockchain/fabric-tools:1.1.0
     imagePullPolicy: Always
-    command: ["sh", "-c", "cryptogen generate --config /sampleconfig/crypto-config.yaml && cp -r crypto-config /shared/ && for file in $(find /shared/ -iname *_sk); do dir=$(dirname $file); mv ${dir}/*_sk ${dir}/key.pem; done && find /shared -type d | xargs chmod a+rx && find /shared -type f | xargs chmod a+r && touch /shared/status_cryptogen_complete "]
+    command: ["sh", "-c", "cryptogen generate --config /shared/config/crypto-config.yaml && cp -r crypto-config /shared/ && for file in $(find /shared/ -iname *_sk); do dir=$(dirname $file); mv ${dir}/*_sk ${dir}/key.pem; done && find /shared -type d | xargs chmod a+rx && find /shared -type f | xargs chmod a+r && touch /shared/status_cryptogen_complete "]
     volumeMounts:
     - mountPath: /shared
       name: shared
   - name: configtxgen
     image: ibmblockchain/fabric-tools:1.1.0
     imagePullPolicy: Always
-    command: ["sh", "-c", "sleep 1 && while [ ! -f /shared/status_cryptogen_complete ]; do echo Waiting for cryptogen; sleep 1; done; cp /sampleconfig/configtx.yaml /shared/configtx.yaml; cd /shared/; configtxgen -profile TwoOrgsOrdererGenesis -outputBlock orderer.block && find /shared -type d | xargs chmod a+rx && find /shared -type f | xargs chmod a+r && touch /shared/status_configtxgen_complete && rm /shared/status_cryptogen_complete"]
+    command: ["sh", "-c", "sleep 1 && while [ ! -f /shared/status_cryptogen_complete ]; do echo Waiting for cryptogen; sleep 1; done; cp /shared/config/configtx.yaml /shared/configtx.yaml; cd /shared/; configtxgen -profile TwoOrgsOrdererGenesis -outputBlock orderer.block && find /shared -type d | xargs chmod a+rx && find /shared -type f | xargs chmod a+r && touch /shared/status_configtxgen_complete && rm /shared/status_cryptogen_complete"]
     env:
      - name: PEERHOST1
        value: blockchain-org1peer1
@@ -48,7 +48,7 @@ spec:
   - name: bootstrap
     image: ibmblockchain/fabric-tools:1.1.0
     imagePullPolicy: Always
-    command: ["sh", "-c", "sleep 1 && while [ ! -f /shared/status_configtxgen_complete ]; do echo Waiting for configtxgen; sleep 1; done && cp -r /sampleconfig/cas /shared && touch /shared/bootstrapped && rm /shared/status_configtxgen_complete && mkdir -p /home/composer/.composer && chown 1000 /home/composer/.composer && echo 'Done with bootstrapping'" ]
+    command: ["sh", "-c", "sleep 1 && while [ ! -f /shared/status_configtxgen_complete ]; do echo Waiting for configtxgen; sleep 1; done && cp -r /shared/config/cas /shared && touch /shared/bootstrapped && rm /shared/status_configtxgen_complete && mkdir -p /home/composer/.composer && chown 1000 /home/composer/.composer && echo 'Done with bootstrapping'" ]
     volumeMounts:
     - mountPath: /shared
       name: shared
@@ -200,6 +200,8 @@ spec:
           value: blockchain-org1peer1:30110
         - name: CORE_PEER_GOSSIP_ORGLEADER
           value: "true"
+        - name: CORE_PEER_GOSSIP_USELEADERELECTION
+          value: "false"
         - name: CORE_PEER_GOSSIP_SKIPHANDSHAKE
           value: "true"
         - name: CORE_PEER_COMMITTER_ENABLED
@@ -288,6 +290,8 @@ spec:
           value: blockchain-org2peer1:30210
         - name: CORE_PEER_GOSSIP_ORGLEADER
           value: "true"
+        - name: CORE_PEER_GOSSIP_USELEADERELECTION
+          value: "false"
         - name: CORE_PEER_GOSSIP_SKIPHANDSHAKE
           value: "true"
         - name: CORE_PEER_COMMITTER_ENABLED
@@ -350,7 +354,7 @@ spec:
     spec:
       containers:
       - name: couchdb1
-        image: ibmblockchain/fabric-couchdb:0.4.6
+        image: ibmblockchain/fabric-couchdb:0.4.10
         env:
         - name: DB_URL
           value: http://localhost:5984/member_db
@@ -369,7 +373,7 @@ spec:
     spec:
       containers:
       - name: couchdb2
-        image: ibmblockchain/fabric-couchdb:0.4.6
+        image: ibmblockchain/fabric-couchdb:0.4.10
         env:
         - name: DB_URL
           value: http://localhost:5984/member_db

--- a/cs-offerings/kube-configs/blockchain-couchdb.yaml
+++ b/cs-offerings/kube-configs/blockchain-couchdb.yaml
@@ -354,7 +354,7 @@ spec:
     spec:
       containers:
       - name: couchdb1
-        image: ibmblockchain/fabric-couchdb:0.4.10
+        image: ibmblockchain/fabric-couchdb:0.4.6
         env:
         - name: DB_URL
           value: http://localhost:5984/member_db
@@ -373,7 +373,7 @@ spec:
     spec:
       containers:
       - name: couchdb2
-        image: ibmblockchain/fabric-couchdb:0.4.10
+        image: ibmblockchain/fabric-couchdb:0.4.6
         env:
         - name: DB_URL
           value: http://localhost:5984/member_db

--- a/cs-offerings/kube-configs/blockchain-prep.yaml
+++ b/cs-offerings/kube-configs/blockchain-prep.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: prep
+spec:
+  restartPolicy: "Never"
+  volumes:
+  - name: shared
+    persistentVolumeClaim:
+      claimName: shared-pvc
+  - name: dockersocket
+    hostPath:
+      path: /var/run/docker.sock
+  containers:
+  - name: bootstrap
+    image: ibmblockchain/fabric-tools:1.1.0
+    imagePullPolicy: Always
+    command: ["sh", "-c", "sleep 100000" ]
+    volumeMounts:
+    - mountPath: /shared
+      name: shared

--- a/cs-offerings/kube-configs/chaincode_install.yaml.base
+++ b/cs-offerings/kube-configs/chaincode_install.yaml.base
@@ -13,7 +13,7 @@ spec:
   - name: chaincodeinstall
     image: ibmblockchain/fabric-tools:1.1.0
     imagePullPolicy: Always
-    command: ["sh", "-c", "git clone -b v1.1.0 https://github.com/hyperledger/fabric $GOPATH/src/github.com/hyperledger/fabric/ && peer chaincode install -n ${CHAINCODE_NAME} -v ${CHAINCODE_VERSION} -p github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02/"]
+    command: ["sh", "-c", "git clone -b release-1.1 https://github.com/hyperledger/fabric-samples $GOPATH/src/github.com/hyperledger/fabric-samples/ && peer chaincode install -n ${CHAINCODE_NAME} -v ${CHAINCODE_VERSION} -p github.com/hyperledger/fabric-samples/chaincode/sacc"]
     env:
     - name: CHAINCODE_NAME
       value: %CHAINCODE_NAME%

--- a/cs-offerings/kube-configs/chaincode_install.yaml.base
+++ b/cs-offerings/kube-configs/chaincode_install.yaml.base
@@ -13,7 +13,7 @@ spec:
   - name: chaincodeinstall
     image: ibmblockchain/fabric-tools:1.1.0
     imagePullPolicy: Always
-    command: ["sh", "-c", "git clone -b release-1.1 https://github.com/hyperledger/fabric-samples $GOPATH/src/github.com/hyperledger/fabric-samples/ && peer chaincode install -n ${CHAINCODE_NAME} -v ${CHAINCODE_VERSION} -p github.com/hyperledger/fabric-samples/chaincode/sacc"]
+    command: ["sh", "-c", "git clone -b v1.1.0 https://github.com/hyperledger/fabric $GOPATH/src/github.com/hyperledger/fabric/ && peer chaincode install -n ${CHAINCODE_NAME} -v ${CHAINCODE_VERSION} -p github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02"]
     env:
     - name: CHAINCODE_NAME
       value: %CHAINCODE_NAME%

--- a/cs-offerings/kube-configs/chaincode_instantiate.yaml.base
+++ b/cs-offerings/kube-configs/chaincode_instantiate.yaml.base
@@ -14,7 +14,7 @@ spec:
   - name: chaincodeinstantiate
     image: ibmblockchain/fabric-tools:1.1.0
     imagePullPolicy: Always
-    command: ["sh", "-c", "peer chaincode instantiate -o blockchain-orderer:31010 -C ${CHANNEL_NAME} -n ${CHAINCODE_NAME} -v ${CHAINCODE_VERSION} -c '{\"Args\":[\"init\",\"a\",\"100\",\"b\",\"200\"]}'"]
+    command: ["sh", "-c", "peer chaincode instantiate -n ${CHAINCODE_NAME} -v ${CHAINCODE_VERSION} -c '{\"Args\":[\"a\",\"100\"]}' -C ${CHANNEL_NAME}"]
     env:
     - name: CHANNEL_NAME
       value: %CHANNEL_NAME%

--- a/cs-offerings/kube-configs/chaincode_instantiate.yaml.base
+++ b/cs-offerings/kube-configs/chaincode_instantiate.yaml.base
@@ -14,7 +14,7 @@ spec:
   - name: chaincodeinstantiate
     image: ibmblockchain/fabric-tools:1.1.0
     imagePullPolicy: Always
-    command: ["sh", "-c", "peer chaincode instantiate -n ${CHAINCODE_NAME} -v ${CHAINCODE_VERSION} -c '{\"Args\":[\"a\",\"100\"]}' -C ${CHANNEL_NAME}"]
+    command: ["sh", "-c", "peer chaincode instantiate -n ${CHAINCODE_NAME} -v ${CHAINCODE_VERSION} -c '{\"Args\":[\"init\",\"a\",\"100\",\"b\",\"200\"]}' -C ${CHANNEL_NAME}"]
     env:
     - name: CHANNEL_NAME
       value: %CHANNEL_NAME%

--- a/cs-offerings/kube-configs/composer-card-import.yaml
+++ b/cs-offerings/kube-configs/composer-card-import.yaml
@@ -26,19 +26,19 @@ spec:
           "version": "1.0.0",
           "peers": {
             "peer0.org1.example.com": {
-                "url": "grpc://localhost:7051",
-                "eventUrl": "grpc://localhost:7053"
+                "url": "grpc://blockchain-org1peer1:30110",
+                "eventUrl": "grpc://blockchain-org1peer1:30111"
               }
             },
-            "ca.org1.example.com": {
-              "url": "http://localhost:7054",
-              "certificateAuthorities": {
-              "caName": "ca.org1.example.com"
-            }
+            "certificateAuthorities": {
+              "ca.org1.example.com": {
+                "url": "http://blockchain-ca:30054",
+                "caName": "CA1"
+              }
           },
           "orderers": {
             "orderer.example.com": {
-              "url": "grpc://localhost:7050"
+              "url": "grpc://blockchain-orderer:31010"
             }
           },
           "organizations": {

--- a/cs-offerings/scripts/config/cas/ca.yaml
+++ b/cs-offerings/scripts/config/cas/ca.yaml
@@ -1,0 +1,245 @@
+#############################################################################
+#   This is a configuration file for the fabric-ca-server command.
+#
+#   COMMAND LINE ARGUMENTS AND ENVIRONMENT VARIABLES
+#   ------------------------------------------------
+#   Each configuration element can be overridden via command line
+#   arguments or environment variables.  The precedence for determining
+#   the value of each element is as follows:
+#   1) command line argument
+#      Examples:
+#      a) --port 443
+#         To set the listening port
+#      b) --ca-keyfile ../mykey.pem
+#         To set the "keyfile" element in the "ca" section below;
+#         note the '-' separator character.
+#   2) environment variable
+#      Examples:
+#      a) FABRIC_CA_SERVER_PORT=443
+#         To set the listening port
+#      b) FABRIC_CA_SERVER_CA_KEYFILE="../mykey.pem"
+#         To set the "keyfile" element in the "ca" section below;
+#         note the '_' separator character.
+#   3) configuration file
+#   4) default value (if there is one)
+#      All default values are shown beside each element below.
+#
+#   FILE NAME ELEMENTS
+#   ------------------
+#   All filename elements below end with the word "file".
+#   For example, see "certfile" and "keyfile" in the "ca" section.
+#   The value of each filename element can be a simple filename, a
+#   relative path, or an absolute path.  If the value is not an
+#   absolute path, it is interpretted as being relative to the location
+#   of this configuration file.
+#
+#############################################################################
+
+# Server's listening port (default: 7054)
+port: 7054
+
+# Enables debug logging (default: false)
+debug: false
+
+#############################################################################
+#  TLS section for the server's listening port
+#
+#  The following types are supported for client authentication: NoClientCert,
+#  RequestClientCert, RequireAnyClientCert, VerfiyClientCertIfGiven,
+#  and RequireAndVerifyClientCert.
+#
+#  Certfiles is a list of root certificate authorities that the server uses
+#  when verifying client certificates.
+#############################################################################
+tls:
+  # Enable TLS (default: false)
+  enabled: false
+  # TLS for the server's listening port
+  certfile: ca-cert.pem
+  keyfile: ca-key.pem
+  clientauth:
+    type: noclientcert
+    certfiles:
+
+#############################################################################
+#  The CA section contains information related to the Certificate Authority
+#  including the name of the CA, which should be unique for all members
+#  of a blockchain network.  It also includes the key and certificate files
+#  used when issuing enrollment certificates (ECerts) and transaction
+#  certificates (TCerts).
+#  The chainfile (if it exists) contains the certificate chain which
+#  should be trusted for this CA, where the 1st in the chain is always the
+#  root CA certificate.
+#############################################################################
+ca:
+  # Name of this CA
+  name: CA
+  # Key file (default: ca-key.pem)
+  keyfile: /shared/crypto-config/ordererOrganizations/example.com/ca/key.pem
+  # Certificate file (default: ca-cert.pem)
+  certfile: /shared/crypto-config/ordererOrganizations/example.com/ca/ca.example.com-cert.pem
+  # Chain file (default: chain-cert.pem)
+  #chainfile: ca-chain.pem
+  chainfile: /shared/crypto-config/ordererOrganizations/example.com/ca/ca.example.com-chain.pem
+
+#############################################################################
+#  The registry section controls how the fabric-ca-server does two things:
+#  1) authenticates enrollment requests which contain a username and password
+#     (also known as an enrollment ID and secret).
+#  2) once authenticated, retrieves the identity's attribute names and
+#     values which the fabric-ca-server optionally puts into TCerts
+#     which it issues for transacting on the Hyperledger Fabric blockchain.
+#     These attributes are useful for making access control decisions in
+#     chaincode.
+#  There are two main configuration options:
+#  1) The fabric-ca-server is the registry
+#  2) An LDAP server is the registry, in which case the fabric-ca-server
+#     calls the LDAP server to perform these tasks.
+#############################################################################
+registry:
+  # Maximum number of times a password/secret can be reused for enrollment
+  # (default: 0, which means there is no limit)
+  maxEnrollments: -1
+
+  # Contains identity information which is used when LDAP is disabled
+  identities:
+     - name: admin
+       pass: adminpw
+       type: client
+       affiliation: ""
+       attrs:
+          hf.Registrar.Roles: "client,user,peer,validator,auditor,ca"
+          hf.Registrar.DelegateRoles: "client,user,validator,auditor"
+          hf.Revoker: true
+          hf.IntermediateCA: true
+
+#############################################################################
+#  Database section
+#  Supported types are: "sqlite3", "postgres", and "mysql".
+#  The datasource value depends on the type.
+#  If the type is "sqlite3", the datasource value is a file name to use
+#  as the database store.  Since "sqlite3" is an embedded database, it
+#  may not be used if you want to run the fabric-ca-server in a cluster.
+#  To run the fabric-ca-server in a cluster, you must choose "postgres"
+#  or "mysql".
+#############################################################################
+db:
+  type: sqlite3
+  datasource: /opt/fabric-ca-server.db
+  tls:
+      enabled: false
+      certfiles:
+        - db-server-cert.pem
+      client:
+        certfile: db-client-cert.pem
+        keyfile: db-client-key.pem
+
+#############################################################################
+#  LDAP section
+#  If LDAP is enabled, the fabric-ca-server calls LDAP to:
+#  1) authenticate enrollment ID and secret (i.e. username and password)
+#     for enrollment requests;
+#  2) To retrieve identity attributes
+#############################################################################
+ldap:
+   # Enables or disables the LDAP client (default: false)
+   enabled: false
+   # The URL of the LDAP server
+   url: ldap://<adminDN>:<adminPassword>@<host>:<port>/<base>
+   tls:
+      certfiles:
+        - ldap-server-cert.pem
+      client:
+         certfile: ldap-client-cert.pem
+         keyfile: ldap-client-key.pem
+
+#############################################################################
+#  Affiliation section
+#############################################################################
+affiliations:
+   org1:
+      - department1
+      - department2
+   org2:
+      - department1
+
+#############################################################################
+#  Signing section
+#############################################################################
+signing:
+    profiles:
+      ca:
+         usage:
+           - cert sign
+         expiry: 8000h
+         caconstraint:
+           isca: true
+    default:
+      usage:
+        - cert sign
+      expiry: 8000h
+
+###########################################################################
+#  Certificate Signing Request section for generating the CA certificate
+###########################################################################
+csr:
+   cn: fabric-ca-server-orderer
+   names:
+      - C: US
+        ST: "North Carolina"
+        L:
+        O: Hyperledger
+        OU: Fabric
+   hosts:
+     - 6a0534cb7c7d
+   ca:
+      pathlen:
+      pathlenzero:
+      expiry:
+
+#############################################################################
+# BCCSP (BlockChain Crypto Service Provider) section is used to select which
+# crypto library implementation to use
+#############################################################################
+
+bccsp:
+    default: SW
+    sw:
+        hash: SHA2
+        security: 256
+        filekeystore:
+            # The directory used for the software file-based keystore
+#            keystore: /opt/keystore
+            keystore: /shared/crypto-config/ordererOrganizations/example.com/ca
+
+#############################################################################
+# The fabric-ca-server init and start commands support the following two
+# additional mutually exclusive options:
+#
+# 1) --cacount <number-of-CAs>
+# Automatically generate multiple default CA instances.
+# This is particularly useful in a development environment to quickly set up
+# multiple CAs.
+# For example,
+#     fabric-ca-server start -b admin:adminpw --cacount 2
+# starts a server with a default CA and two non-default CA's with names
+# 'ca1' and 'ca2'.
+#
+# 2) --cafiles <CA-config-files>
+# For each CA config file in the list, generate a separate signing CA.  Each CA
+# config file in this list MAY contain all of the same elements as are found in
+# the server config file except port, debug, and tls sections.
+# For example,
+#    fabric-ca-server start -b admin:adminpw                \
+#          --cafiles ca/ca1/fabric-ca-server-config.yaml    \
+#          --cafiles ca/ca2/fabric-ca-server-config.yaml
+# is equivalent to the previous example, except the files CA config files
+# must already exist and can be customized.
+#
+#############################################################################
+
+cacount:
+
+cafiles:
+  - /shared/cas/org1/ca.yaml
+  - /shared/cas/org2/ca.yaml

--- a/cs-offerings/scripts/config/cas/org1/ca.yaml
+++ b/cs-offerings/scripts/config/cas/org1/ca.yaml
@@ -1,0 +1,243 @@
+#############################################################################
+#   This is a configuration file for the fabric-ca-server command.
+#
+#   COMMAND LINE ARGUMENTS AND ENVIRONMENT VARIABLES
+#   ------------------------------------------------
+#   Each configuration element can be overridden via command line
+#   arguments or environment variables.  The precedence for determining
+#   the value of each element is as follows:
+#   1) command line argument
+#      Examples:
+#      a) --port 443
+#         To set the listening port
+#      b) --ca-keyfile ../mykey.pem
+#         To set the "keyfile" element in the "ca" section below;
+#         note the '-' separator character.
+#   2) environment variable
+#      Examples:
+#      a) FABRIC_CA_SERVER_PORT=443
+#         To set the listening port
+#      b) FABRIC_CA_SERVER_CA_KEYFILE="../mykey.pem"
+#         To set the "keyfile" element in the "ca" section below;
+#         note the '_' separator character.
+#   3) configuration file
+#   4) default value (if there is one)
+#      All default values are shown beside each element below.
+#
+#   FILE NAME ELEMENTS
+#   ------------------
+#   All filename elements below end with the word "file".
+#   For example, see "certfile" and "keyfile" in the "ca" section.
+#   The value of each filename element can be a simple filename, a
+#   relative path, or an absolute path.  If the value is not an
+#   absolute path, it is interpretted as being relative to the location
+#   of this configuration file.
+#
+#############################################################################
+
+# Server's listening port (default: 7054)
+port: 7055
+
+# Enables debug logging (default: false)
+debug: true
+
+#############################################################################
+#  TLS section for the server's listening port
+#
+#  The following types are supported for client authentication: NoClientCert,
+#  RequestClientCert, RequireAnyClientCert, VerfiyClientCertIfGiven,
+#  and RequireAndVerifyClientCert.
+#
+#  Certfiles is a list of root certificate authorities that the server uses
+#  when verifying client certificates.
+#############################################################################
+tls:
+  # Enable TLS (default: false)
+  enabled: false
+  # TLS for the server's listening port
+  certfile: ca-cert.pem
+  keyfile: ca-key.pem
+  clientauth:
+    type: noclientcert
+    certfiles:
+
+#############################################################################
+#  The CA section contains information related to the Certificate Authority
+#  including the name of the CA, which should be unique for all members
+#  of a blockchain network.  It also includes the key and certificate files
+#  used when issuing enrollment certificates (ECerts) and transaction
+#  certificates (TCerts).
+#  The chainfile (if it exists) contains the certificate chain which
+#  should be trusted for this CA, where the 1st in the chain is always the
+#  root CA certificate.
+#############################################################################
+ca:
+  # Name of this CA
+  name: CA1
+  # Key file (default: ca-key.pem)
+  keyfile: /shared/crypto-config/peerOrganizations/org1.example.com/ca/key.pem
+  # Certificate file (default: ca-cert.pem)
+  certfile: /shared/crypto-config/peerOrganizations/org1.example.com/ca/ca.org1.example.com-cert.pem
+  # Chain file (default: chain-cert.pem)
+  #chainfile: ca-chain.pem
+  chainfile: /shared/crypto-config/peerOrganizations/org1.example.com/ca/ca.org1.example.com-chain.pem
+
+#############################################################################
+#  The registry section controls how the fabric-ca-server does two things:
+#  1) authenticates enrollment requests which contain a username and password
+#     (also known as an enrollment ID and secret).
+#  2) once authenticated, retrieves the identity's attribute names and
+#     values which the fabric-ca-server optionally puts into TCerts
+#     which it issues for transacting on the Hyperledger Fabric blockchain.
+#     These attributes are useful for making access control decisions in
+#     chaincode.
+#  There are two main configuration options:
+#  1) The fabric-ca-server is the registry
+#  2) An LDAP server is the registry, in which case the fabric-ca-server
+#     calls the LDAP server to perform these tasks.
+#############################################################################
+registry:
+  # Maximum number of times a password/secret can be reused for enrollment
+  # (default: 0, which means there is no limit)
+  maxEnrollments: -1
+
+  # Contains identity information which is used when LDAP is disabled
+  identities:
+     - name: admin
+       pass: adminpw
+       type: client
+       affiliation: ""
+       attrs:
+          hf.Registrar.Roles: "client,user,peer,validator,auditor,ca"
+          hf.Registrar.DelegateRoles: "client,user,validator,auditor"
+          hf.Revoker: true
+          hf.IntermediateCA: true
+
+#############################################################################
+#  Database section
+#  Supported types are: "sqlite3", "postgres", and "mysql".
+#  The datasource value depends on the type.
+#  If the type is "sqlite3", the datasource value is a file name to use
+#  as the database store.  Since "sqlite3" is an embedded database, it
+#  may not be used if you want to run the fabric-ca-server in a cluster.
+#  To run the fabric-ca-server in a cluster, you must choose "postgres"
+#  or "mysql".
+#############################################################################
+db:
+  type: sqlite3
+  datasource: /opt/fabric-ca1-server.db
+  tls:
+      enabled: false
+      certfiles:
+        - db-server-cert.pem
+      client:
+        certfile: db-client-cert.pem
+        keyfile: db-client-key.pem
+
+#############################################################################
+#  LDAP section
+#  If LDAP is enabled, the fabric-ca-server calls LDAP to:
+#  1) authenticate enrollment ID and secret (i.e. username and password)
+#     for enrollment requests;
+#  2) To retrieve identity attributes
+#############################################################################
+ldap:
+   # Enables or disables the LDAP client (default: false)
+   enabled: false
+   # The URL of the LDAP server
+   url: ldap://<adminDN>:<adminPassword>@<host>:<port>/<base>
+   tls:
+      certfiles:
+        - ldap-server-cert.pem
+      client:
+         certfile: ldap-client-cert.pem
+         keyfile: ldap-client-key.pem
+
+#############################################################################
+#  Affiliation section
+#############################################################################
+affiliations:
+   org1:
+      - department1
+      - department2
+   org2:
+      - department1
+
+#############################################################################
+#  Signing section
+#############################################################################
+signing:
+    profiles:
+      ca:
+         usage:
+           - cert sign
+         expiry: 8000h
+         caconstraint:
+           isca: true
+    default:
+      usage:
+        - cert sign
+      expiry: 8000h
+
+###########################################################################
+#  Certificate Signing Request section for generating the CA certificate
+###########################################################################
+csr:
+   cn: fabric-ca-server-org1
+   names:
+      - C: US
+        ST: "North Carolina"
+        L:
+        O: Hyperledger
+        OU: Fabric
+   hosts:
+     - 6a0534cb7c7d
+   ca:
+      pathlen:
+      pathlenzero:
+      expiry:
+
+#############################################################################
+# BCCSP (BlockChain Crypto Service Provider) section is used to select which
+# crypto library implementation to use
+#############################################################################
+
+bccsp:
+    default: SW
+    sw:
+        hash: SHA2
+        security: 256
+        filekeystore:
+            # The directory used for the software file-based keystore
+            #keystore: /opt/keystore
+            keystore: /shared/crypto-config/peerOrganizations/org1.example.com/ca
+
+#############################################################################
+# The fabric-ca-server init and start commands support the following two
+# additional mutually exclusive options:
+#
+# 1) --cacount <number-of-CAs>
+# Automatically generate multiple default CA instances.
+# This is particularly useful in a development environment to quickly set up
+# multiple CAs.
+# For example,
+#     fabric-ca-server start -b admin:adminpw --cacount 2
+# starts a server with a default CA and two non-default CA's with names
+# 'ca1' and 'ca2'.
+#
+# 2) --cafiles <CA-config-files>
+# For each CA config file in the list, generate a separate signing CA.  Each CA
+# config file in this list MAY contain all of the same elements as are found in
+# the server config file except port, debug, and tls sections.
+# For example,
+#    fabric-ca-server start -b admin:adminpw                \
+#          --cafiles ca/ca1/fabric-ca-server-config.yaml    \
+#          --cafiles ca/ca2/fabric-ca-server-config.yaml
+# is equivalent to the previous example, except the files CA config files
+# must already exist and can be customized.
+#
+#############################################################################
+
+cacount: 
+
+cafiles:

--- a/cs-offerings/scripts/config/cas/org2/ca.yaml
+++ b/cs-offerings/scripts/config/cas/org2/ca.yaml
@@ -1,0 +1,242 @@
+#############################################################################
+#   This is a configuration file for the fabric-ca-server command.
+#
+#   COMMAND LINE ARGUMENTS AND ENVIRONMENT VARIABLES
+#   ------------------------------------------------
+#   Each configuration element can be overridden via command line
+#   arguments or environment variables.  The precedence for determining
+#   the value of each element is as follows:
+#   1) command line argument
+#      Examples:
+#      a) --port 443
+#         To set the listening port
+#      b) --ca-keyfile ../mykey.pem
+#         To set the "keyfile" element in the "ca" section below;
+#         note the '-' separator character.
+#   2) environment variable
+#      Examples:
+#      a) FABRIC_CA_SERVER_PORT=443
+#         To set the listening port
+#      b) FABRIC_CA_SERVER_CA_KEYFILE="../mykey.pem"
+#         To set the "keyfile" element in the "ca" section below;
+#         note the '_' separator character.
+#   3) configuration file
+#   4) default value (if there is one)
+#      All default values are shown beside each element below.
+#
+#   FILE NAME ELEMENTS
+#   ------------------
+#   All filename elements below end with the word "file".
+#   For example, see "certfile" and "keyfile" in the "ca" section.
+#   The value of each filename element can be a simple filename, a
+#   relative path, or an absolute path.  If the value is not an
+#   absolute path, it is interpretted as being relative to the location
+#   of this configuration file.
+#
+#############################################################################
+
+# Server's listening port (default: 7054)
+port: 7055
+
+# Enables debug logging (default: false)
+debug: true
+
+#############################################################################
+#  TLS section for the server's listening port
+#
+#  The following types are supported for client authentication: NoClientCert,
+#  RequestClientCert, RequireAnyClientCert, VerfiyClientCertIfGiven,
+#  and RequireAndVerifyClientCert.
+#
+#  Certfiles is a list of root certificate authorities that the server uses
+#  when verifying client certificates.
+#############################################################################
+tls:
+  # Enable TLS (default: false)
+  enabled: false
+  # TLS for the server's listening port
+  certfile: ca-cert.pem
+  keyfile: ca-key.pem
+  clientauth:
+    type: noclientcert
+    certfiles:
+
+#############################################################################
+#  The CA section contains information related to the Certificate Authority
+#  including the name of the CA, which should be unique for all members
+#  of a blockchain network.  It also includes the key and certificate files
+#  used when issuing enrollment certificates (ECerts) and transaction
+#  certificates (TCerts).
+#  The chainfile (if it exists) contains the certificate chain which
+#  should be trusted for this CA, where the 1st in the chain is always the
+#  root CA certificate.
+#############################################################################
+ca:
+  # Name of this CA
+  name: CA2
+  # Key file (default: ca-key.pem)
+  keyfile: /shared/crypto-config/peerOrganizations/org2.example.com/ca/key.pem
+  # Certificate file (default: ca-cert.pem)
+  certfile: /shared/crypto-config/peerOrganizations/org2.example.com/ca/ca.org2.example.com-cert.pem
+  # Chain file (default: chain-cert.pem)
+  #chainfile: ca-chain.pem
+  chainfile: /shared/crypto-config/peerOrganizations/org2.example.com/ca/ca.org2.example.com-chain.pem
+
+#############################################################################
+#  The registry section controls how the fabric-ca-server does two things:
+#  1) authenticates enrollment requests which contain a username and password
+#     (also known as an enrollment ID and secret).
+#  2) once authenticated, retrieves the identity's attribute names and
+#     values which the fabric-ca-server optionally puts into TCerts
+#     which it issues for transacting on the Hyperledger Fabric blockchain.
+#     These attributes are useful for making access control decisions in
+#     chaincode.
+#  There are two main configuration options:
+#  1) The fabric-ca-server is the registry
+#  2) An LDAP server is the registry, in which case the fabric-ca-server
+#     calls the LDAP server to perform these tasks.
+#############################################################################
+registry:
+  # Maximum number of times a password/secret can be reused for enrollment
+  # (default: 0, which means there is no limit)
+  maxEnrollments: -1
+
+  # Contains identity information which is used when LDAP is disabled
+  identities:
+     - name: admin
+       pass: adminpw
+       type: client
+       affiliation: ""
+       attrs:
+          hf.Registrar.Roles: "client,user,peer,validator,auditor,ca"
+          hf.Registrar.DelegateRoles: "client,user,validator,auditor"
+          hf.Revoker: true
+          hf.IntermediateCA: true
+
+#############################################################################
+#  Database section
+#  Supported types are: "sqlite3", "postgres", and "mysql".
+#  The datasource value depends on the type.
+#  If the type is "sqlite3", the datasource value is a file name to use
+#  as the database store.  Since "sqlite3" is an embedded database, it
+#  may not be used if you want to run the fabric-ca-server in a cluster.
+#  To run the fabric-ca-server in a cluster, you must choose "postgres"
+#  or "mysql".
+#############################################################################
+db:
+  type: sqlite3
+  datasource: /opt/fabric-ca2-server.db
+  tls:
+      enabled: false
+      certfiles:
+        - db-server-cert.pem
+      client:
+        certfile: db-client-cert.pem
+        keyfile: db-client-key.pem
+
+#############################################################################
+#  LDAP section
+#  If LDAP is enabled, the fabric-ca-server calls LDAP to:
+#  1) authenticate enrollment ID and secret (i.e. username and password)
+#     for enrollment requests;
+#  2) To retrieve identity attributes
+#############################################################################
+ldap:
+   # Enables or disables the LDAP client (default: false)
+   enabled: false
+   # The URL of the LDAP server
+   url: ldap://<adminDN>:<adminPassword>@<host>:<port>/<base>
+   tls:
+      certfiles:
+        - ldap-server-cert.pem
+      client:
+         certfile: ldap-client-cert.pem
+         keyfile: ldap-client-key.pem
+
+#############################################################################
+#  Affiliation section
+#############################################################################
+affiliations:
+   org1:
+      - department1
+      - department2
+   org2:
+      - department1
+
+#############################################################################
+#  Signing section
+#############################################################################
+signing:
+    profiles:
+      ca:
+         usage:
+           - cert sign
+         expiry: 8000h
+         caconstraint:
+           isca: true
+    default:
+      usage:
+        - cert sign
+      expiry: 8000h
+
+###########################################################################
+#  Certificate Signing Request section for generating the CA certificate
+###########################################################################
+csr:
+   cn: fabric-ca-server-org2
+   names:
+      - C: US
+        ST: "North Carolina"
+        L:
+        O: Hyperledger
+        OU: Fabric
+   hosts:
+     - 6a0534cb7c7d
+   ca:
+      pathlen:
+      pathlenzero:
+      expiry:
+
+#############################################################################
+# BCCSP (BlockChain Crypto Service Provider) section is used to select which
+# crypto library implementation to use
+#############################################################################
+
+bccsp:
+    default: SW
+    sw:
+        hash: SHA2
+        security: 256
+        filekeystore:
+            # The directory used for the software file-based keystore
+            keystore: /shared/crypto-config/peerOrganizations/org2.example.com/ca
+
+#############################################################################
+# The fabric-ca-server init and start commands support the following two
+# additional mutually exclusive options:
+#
+# 1) --cacount <number-of-CAs>
+# Automatically generate multiple default CA instances.
+# This is particularly useful in a development environment to quickly set up
+# multiple CAs.
+# For example,
+#     fabric-ca-server start -b admin:adminpw --cacount 2
+# starts a server with a default CA and two non-default CA's with names
+# 'ca1' and 'ca2'.
+#
+# 2) --cafiles <CA-config-files>
+# For each CA config file in the list, generate a separate signing CA.  Each CA
+# config file in this list MAY contain all of the same elements as are found in
+# the server config file except port, debug, and tls sections.
+# For example,
+#    fabric-ca-server start -b admin:adminpw                \
+#          --cafiles ca/ca1/fabric-ca-server-config.yaml    \
+#          --cafiles ca/ca2/fabric-ca-server-config.yaml
+# is equivalent to the previous example, except the files CA config files
+# must already exist and can be customized.
+#
+#############################################################################
+
+cacount: 
+
+cafiles:

--- a/cs-offerings/scripts/config/configtx.yaml
+++ b/cs-offerings/scripts/config/configtx.yaml
@@ -1,0 +1,151 @@
+---
+################################################################################
+#
+#   Profile
+#
+#   - Different configuration profiles may be encoded here to be specified
+#   as parameters to the configtxgen tool
+#
+################################################################################
+Profiles:
+    TwoOrgsOrdererGenesis:
+        Capabilities:
+            <<: *ChannelCapabilities
+        Orderer:
+            <<: *OrdererDefaults
+            Organizations:
+                - *OrdererOrg
+
+            Capabilities:
+             <<: *OrdererCapabilities
+        Consortiums:
+            SampleConsortium:
+                Organizations:
+                    - *Org1
+                    - *Org2
+
+    TwoOrgsChannel:
+        Consortium: SampleConsortium
+        Application:
+            <<: *ApplicationDefaults
+            Organizations:
+               - *Org1
+               - *Org2
+
+
+################################################################################
+#
+#   Section: Organizations
+#
+#   - This section defines the different organizational identities which will
+#   be referenced later in the configuration.
+#
+################################################################################
+Organizations:
+
+    - &OrdererOrg
+        Name: OrdererOrg
+        ID: OrdererMSP
+        MSPDir: crypto-config/ordererOrganizations/example.com/msp
+        AdminPrincipal: Role.MEMBER
+
+
+    - &Org1
+        Name: Org1MSP
+        ID: Org1MSP
+        MSPDir: crypto-config/peerOrganizations/org1.example.com/msp
+        AdminPrincipal: Role.MEMBER
+
+        AnchorPeers:
+            - Host: blockchain-org1peer1
+              Port: 30110
+    - &Org2
+        Name: Org2MSP
+        ID: Org2MSP
+        MSPDir: crypto-config/peerOrganizations/org2.example.com/msp
+        AdminPrincipal: Role.MEMBER
+
+        AnchorPeers:
+            - Host: blockchain-org2peer1
+              Port: 30210
+
+
+################################################################################
+#
+#   SECTION: Orderer
+#
+#   - This section defines the values to encode into a config transaction or
+#   genesis block for orderer related parameters
+#
+################################################################################
+Orderer: &OrdererDefaults
+
+    OrdererType: solo
+    Addresses:
+        - blockchain-orderer:31010
+
+    BatchTimeout: 2s
+    BatchSize:
+        MaxMessageCount: 10
+        AbsoluteMaxBytes: 99 MB
+        PreferredMaxBytes: 512 KB
+    MaxChannels: 1000
+    Kafka:
+        Brokers:
+
+    Organizations:
+
+################################################################################
+#
+#   SECTION: Application
+#
+#   - This section defines the values to encode into a config transaction or
+#   genesis block for application related parameters
+#
+################################################################################
+Application: &ApplicationDefaults
+    Organizations:
+
+Capabilities:
+    # Channel capabilities apply to both the orderers and the peers and must be
+    # supported by both.  Set the value of the capability to true to require it.
+    Channel: &ChannelCapabilities
+        # V1.1 for Channel is a catchall flag for behavior which has been
+        # determined to be desired for all orderers and peers running v1.0.x,
+        # but the modification of which would cause incompatibilities.  Users
+        # should leave this flag set to true.
+        V1_1: true
+    # Orderer capabilities apply only to the orderers, and may be safely
+    # manipulated without concern for upgrading peers.  Set the value of the
+    # capability to true to require it.
+    Orderer: &OrdererCapabilities
+        # V1.1 for Order is a catchall flag for behavior which has been
+        # determined to be desired for all orderers running v1.0.x, but the
+        # modification of which  would cause incompatibilities.  Users should
+        # leave this flag set to true.
+        V1_1: true
+    # Application capabilities apply only to the peer network, and may be safely
+    # manipulated without concern for upgrading orderers.  Set the value of the
+    # capability to true to require it.
+    Application: &ApplicationCapabilities
+        # V1.1 for Application is a catchall flag for behavior which has been
+        # determined to be desired for all peers running v1.0.x, but the
+        # modification of which would cause incompatibilities.  Users should
+        # leave this flag set to true.
+        V1_1: true
+        # V1_1_PVTDATA_EXPERIMENTAL is an Application capability to enable the
+        # private data capability.  It is only supported when using peers built
+        # with experimental build tag.  When set to true, private data
+        # collections can be configured upon chaincode instantiation and
+        # utilized within chaincode Invokes.
+        # Note that use of this feature with non "experimental" binaries on
+        # the network may cause a fork.
+        V1_1_PVTDATA_EXPERIMENTAL: false
+        # V1_1_RESOURCETREE_EXPERIMENTAL is an Application capability to enable the
+        # resources capability. Currently this is needed for defining resource based
+        # access control (RBAC). RBAC helps set fine-grained access control on system
+        # resources such as the endorser and various system chaincodes. Default is V1.0
+        # based access control based on CHANNEL_READERS and CHANNEL_WRITERS
+        # Note that use of this feature with non "experimental" binaries on
+        # the network may cause a fork.
+        V1_1_RESOURCETREE_EXPERIMENTAL: false

--- a/cs-offerings/scripts/config/crypto-config.yaml
+++ b/cs-offerings/scripts/config/crypto-config.yaml
@@ -1,0 +1,76 @@
+# ---------------------------------------------------------------------------
+# "OrdererOrgs" - Definition of organizations managing orderer nodes
+# ---------------------------------------------------------------------------
+OrdererOrgs:
+  # ---------------------------------------------------------------------------
+  # Orderer
+  # ---------------------------------------------------------------------------
+  - Name: Orderer
+    Domain: example.com
+    # ---------------------------------------------------------------------------
+    # "Specs" - See PeerOrgs below for complete description
+    # ---------------------------------------------------------------------------
+    Specs:
+      - Hostname: orderer
+# ---------------------------------------------------------------------------
+# "PeerOrgs" - Definition of organizations managing peer nodes
+# ---------------------------------------------------------------------------
+PeerOrgs:
+  # ---------------------------------------------------------------------------
+  # Org1
+  # ---------------------------------------------------------------------------
+  - Name: Org1
+    Domain: org1.example.com
+    # ---------------------------------------------------------------------------
+    # "Specs"
+    # ---------------------------------------------------------------------------
+    # Uncomment this section to enable the explicit definition of hosts in your
+    # configuration.  Most users will want to use Template, below
+    #
+    # Specs is an array of Spec entries.  Each Spec entry consists of two fields:
+    #   - Hostname:   (Required) The desired hostname, sans the domain.
+    #   - CommonName: (Optional) Specifies the template or explicit override for
+    #                 the CN.  By default, this is the template:
+    #
+    #                              "{{.Hostname}}.{{.Domain}}"
+    #
+    #                 which obtains its values from the Spec.Hostname and
+    #                 Org.Domain, respectively.
+    # ---------------------------------------------------------------------------
+    # Specs:
+    #   - Hostname: foo # implicitly "foo.org1.example.com"
+    #     CommonName: foo27.org5.example.com # overrides Hostname-based FQDN set above
+    #   - Hostname: bar
+    #   - Hostname: baz
+    # ---------------------------------------------------------------------------
+    # "Template"
+    # ---------------------------------------------------------------------------
+    # Allows for the definition of 1 or more hosts that are created sequentially
+    # from a template. By default, this looks like "peer%d" from 0 to Count-1.
+    # You may override the number of nodes (Count), the starting index (Start)
+    # or the template used to construct the name (Hostname).
+    #
+    # Note: Template and Specs are not mutually exclusive.  You may define both
+    # sections and the aggregate nodes will be created for you.  Take care with
+    # name collisions
+    # ---------------------------------------------------------------------------
+    Template:
+      Count: 2
+      # Start: 5
+      # Hostname: {{.Prefix}}{{.Index}} # default
+    # ---------------------------------------------------------------------------
+    # "Users"
+    # ---------------------------------------------------------------------------
+    # Count: The number of user accounts _in addition_ to Admin
+    # ---------------------------------------------------------------------------
+    Users:
+      Count: 1
+  # ---------------------------------------------------------------------------
+  # Org2: See "Org1" for full specification
+  # ---------------------------------------------------------------------------
+  - Name: Org2
+    Domain: org2.example.com
+    Template:
+      Count: 2
+    Users:
+      Count: 1

--- a/cs-offerings/scripts/create_all.sh
+++ b/cs-offerings/scripts/create_all.sh
@@ -33,7 +33,7 @@ CHANNEL_NAME="composerchannel" PEER_MSPID="Org2MSP" PEER_ADDRESS="blockchain-org
 
 echo ""
 echo "=> CREATE_ALL: Creating composer playground"
-#create/create_composer-playground.sh $@
+create/create_composer-playground.sh $@
 
 # Can't create this until the user has performed manual actions in the Composer Playground.
 # echo ""

--- a/cs-offerings/scripts/create_all.sh
+++ b/cs-offerings/scripts/create_all.sh
@@ -42,12 +42,12 @@ create/create_composer-playground.sh $@
 
 echo ""
 echo "=> CREATE_ALL: Running Install Chaincode on Org1 Peer1"
-CHAINCODE_NAME="sacc" CHAINCODE_VERSION="v1" MSP_CONFIGPATH="/shared/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp"  PEER_MSPID="Org1MSP" PEER_ADDRESS="blockchain-org1peer1:30110" create/chaincode_install.sh
+CHAINCODE_NAME="chaincode_example02" CHAINCODE_VERSION="v1" MSP_CONFIGPATH="/shared/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp"  PEER_MSPID="Org1MSP" PEER_ADDRESS="blockchain-org1peer1:30110" create/chaincode_install.sh
 
 echo ""
 echo "=> CREATE_ALL: Running Install Chaincode on Org2 Peer1"
-CHAINCODE_NAME="sacc" CHAINCODE_VERSION="v1" MSP_CONFIGPATH="/shared/crypto-config/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp"  PEER_MSPID="Org2MSP" PEER_ADDRESS="blockchain-org2peer1:30210" create/chaincode_install.sh
+CHAINCODE_NAME="chaincode_example02" CHAINCODE_VERSION="v1" MSP_CONFIGPATH="/shared/crypto-config/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp"  PEER_MSPID="Org2MSP" PEER_ADDRESS="blockchain-org2peer1:30210" create/chaincode_install.sh
 
 echo ""
 echo "=> CREATE_ALL: Running instantiate chaincode on channel \"composerchannel\" using \"Org1MSP\""
-CHANNEL_NAME="composerchannel" CHAINCODE_NAME="sacc" CHAINCODE_VERSION="v1" MSP_CONFIGPATH="/shared/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp"  PEER_MSPID="Org1MSP" PEER_ADDRESS="blockchain-org1peer1:30110" create/chaincode_instantiate.sh
+CHANNEL_NAME="composerchannel" CHAINCODE_NAME="chaincode_example02" CHAINCODE_VERSION="v1" MSP_CONFIGPATH="/shared/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp"  PEER_MSPID="Org1MSP" PEER_ADDRESS="blockchain-org1peer1:30110" create/chaincode_instantiate.sh

--- a/cs-offerings/scripts/create_all.sh
+++ b/cs-offerings/scripts/create_all.sh
@@ -10,7 +10,7 @@ else
 fi
 
 echo "clearing all old pods"
-./delete_all.sh
+#./delete_all.sh
 
 echo ""
 echo "=> CREATE_ALL: Creating storage"
@@ -33,7 +33,7 @@ CHANNEL_NAME="composerchannel" PEER_MSPID="Org2MSP" PEER_ADDRESS="blockchain-org
 
 echo ""
 echo "=> CREATE_ALL: Creating composer playground"
-create/create_composer-playground.sh $@
+#create/create_composer-playground.sh $@
 
 # Can't create this until the user has performed manual actions in the Composer Playground.
 # echo ""
@@ -42,12 +42,12 @@ create/create_composer-playground.sh $@
 
 echo ""
 echo "=> CREATE_ALL: Running Install Chaincode on Org1 Peer1"
-CHAINCODE_NAME="example02" CHAINCODE_VERSION="v1" MSP_CONFIGPATH="/shared/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp"  PEER_MSPID="Org1MSP" PEER_ADDRESS="blockchain-org1peer1:30110" create/chaincode_install.sh
+CHAINCODE_NAME="sacc" CHAINCODE_VERSION="v1" MSP_CONFIGPATH="/shared/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp"  PEER_MSPID="Org1MSP" PEER_ADDRESS="blockchain-org1peer1:30110" create/chaincode_install.sh
 
 echo ""
 echo "=> CREATE_ALL: Running Install Chaincode on Org2 Peer1"
-CHAINCODE_NAME="example02" CHAINCODE_VERSION="v1" MSP_CONFIGPATH="/shared/crypto-config/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp"  PEER_MSPID="Org2MSP" PEER_ADDRESS="blockchain-org2peer1:30210" create/chaincode_install.sh
+CHAINCODE_NAME="sacc" CHAINCODE_VERSION="v1" MSP_CONFIGPATH="/shared/crypto-config/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp"  PEER_MSPID="Org2MSP" PEER_ADDRESS="blockchain-org2peer1:30210" create/chaincode_install.sh
 
 echo ""
 echo "=> CREATE_ALL: Running instantiate chaincode on channel \"composerchannel\" using \"Org1MSP\""
-CHANNEL_NAME="composerchannel" CHAINCODE_NAME="example02" CHAINCODE_VERSION="v1" MSP_CONFIGPATH="/shared/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp"  PEER_MSPID="Org1MSP" PEER_ADDRESS="blockchain-org1peer1:30110" create/chaincode_instantiate.sh
+CHANNEL_NAME="composerchannel" CHAINCODE_NAME="sacc" CHAINCODE_VERSION="v1" MSP_CONFIGPATH="/shared/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp"  PEER_MSPID="Org1MSP" PEER_ADDRESS="blockchain-org1peer1:30110" create/chaincode_instantiate.sh

--- a/cs-offerings/scripts/delete/delete_chaincode-install.sh
+++ b/cs-offerings/scripts/delete/delete_chaincode-install.sh
@@ -21,12 +21,12 @@ echo "Preparing yaml for chaincodeinstall pod"
 sed -e "s/%PEER_ADDRESS%/${PEER_ADDRESS}/g" -e "s/%PEER_MSPID%/${PEER_MSPID}/g" -e "s|%MSP_CONFIGPATH%|${MSP_CONFIGPATH}|g"  -e "s/%CHAINCODE_NAME%/${CHAINCODE_NAME}/g" -e "s/%CHAINCODE_VERSION%/${CHAINCODE_VERSION}/g" ${KUBECONFIG_FOLDER}/chaincode_install.yaml.base > ${KUBECONFIG_FOLDER}/chaincode_install.yaml
 
 echo "Deleting Existing Install Chaincode Pod"
-if [ "$(kubectl get pods | grep chaincodeinstall | wc -l | awk '{print $1}')" != "0" ]; then
+if [ "$(kubectl get pods chaincodeinstall | grep chaincodeinstall | wc -l | awk '{print $1}')" != "0" ]; then
     echo "Running: kubectl delete -f ${KUBECONFIG_FOLDER}/chaincode_install.yaml"
     kubectl delete -f ${KUBECONFIG_FOLDER}/chaincode_install.yaml
 
     # Wait for the pod to be deleted
-    while [ "$(kubectl get pods | grep chaincodeinstall | wc -l | awk '{print $1}')" != "0" ]; do
+    while [ "$(kubectl get pods chaincodeinstall | grep chaincodeinstall | wc -l | awk '{print $1}')" != "0" ]; do
         echo "Waiting for old install chaincode Pod to be deleted"
         sleep 1;
     done

--- a/cs-offerings/scripts/delete/delete_chaincode-instantiate.sh
+++ b/cs-offerings/scripts/delete/delete_chaincode-instantiate.sh
@@ -21,12 +21,12 @@ echo "Preparing yaml for chaincode instantiate delete"
 sed -e "s/%CHANNEL_NAME%/${CHANNEL_NAME}/g" -e "s/%PEER_ADDRESS%/${PEER_ADDRESS}/g" -e "s/%PEER_MSPID%/${PEER_MSPID}/g" -e "s|%MSP_CONFIGPATH%|${MSP_CONFIGPATH}|g"  -e "s/%CHAINCODE_NAME%/${CHAINCODE_NAME}/g" -e "s/%CHAINCODE_VERSION%/${CHAINCODE_VERSION}/g" ${KUBECONFIG_FOLDER}/chaincode_instantiate.yaml.base > ${KUBECONFIG_FOLDER}/chaincode_instantiate.yaml
 
 echo "Deleting Existing Instantiate Chaincode Pod"
-if [ "$(kubectl get pods | grep chaincodeinstantiate | wc -l | awk '{print $1}')" != "0" ]; then
+if [ "$(kubectl get pods chaincodeinstantiate | grep chaincodeinstantiate | wc -l | awk '{print $1}')" != "0" ]; then
     echo "Running: kubectl delete -f ${KUBECONFIG_FOLDER}/chaincode_instantiate.yaml"
     kubectl delete -f ${KUBECONFIG_FOLDER}/chaincode_instantiate.yaml
 
     # Wait for the pod to be deleted
-    while [ "$(kubectl get pods | grep chaincodeinstantiate | wc -l | awk '{print $1}')" != "0" ]; do
+    while [ "$(kubectl get pods chaincodeinstantiate | grep chaincodeinstantiate | wc -l | awk '{print $1}')" != "0" ]; do
         echo "Waiting for old instantiate chaincode Pod to be deleted"
         sleep 1;
     done

--- a/cs-offerings/scripts/delete/delete_channel-pods.sh
+++ b/cs-offerings/scripts/delete/delete_channel-pods.sh
@@ -18,12 +18,12 @@ echo "Preparing yaml for createchannel pod for deletion"
 sed -e "s/%PEER_ADDRESS%/${PEER_ADDRESS}/g" -e "s/%CHANNEL_NAME%/${CHANNEL_NAME}/g" -e "s/%PEER_MSPID%/${PEER_MSPID}/g" ${KUBECONFIG_FOLDER}/create_channel.yaml.base > ${KUBECONFIG_FOLDER}/create_channel.yaml
 
 echo "Deleting Existing Create Channel Pod"
-if [ "$(kubectl get pods | grep createchannel | wc -l | awk '{print $1}')" != "0" ]; then
+if [ "$(kubectl get pods createchannel | grep createchannel | wc -l | awk '{print $1}')" != "0" ]; then
 	echo "Running: kubectl delete -f ${KUBECONFIG_FOLDER}/create_channel.yaml"
     kubectl delete -f ${KUBECONFIG_FOLDER}/create_channel.yaml
 
     # Wait for the pod to be deleted
-    while [ "$(kubectl get pods | grep createchannel | wc -l | awk '{print $1}')" != "0" ]; do
+    while [ "$(kubectl get pods createchannel | grep createchannel | wc -l | awk '{print $1}')" != "0" ]; do
         echo "Waiting for old Create Channel Pod to be deleted"
         sleep 1;
     done
@@ -37,13 +37,13 @@ fi
 echo "Preparing yaml for joinchannel pod for deletion"
 sed -e "s/%PEER_ADDRESS%/${PEER_ADDRESS}/g" -e "s/%CHANNEL_NAME%/${CHANNEL_NAME}/g" -e "s/%PEER_MSPID%/${PEER_MSPID}/g" -e "s|%MSP_CONFIGPATH%|${MSP_CONFIGPATH}|g" ${KUBECONFIG_FOLDER}/join_channel.yaml.base > ${KUBECONFIG_FOLDER}/join_channel.yaml
 
-if [ "$(kubectl get pods | grep joinchannel | wc -l | awk '{print $1}')" != "0" ]; then
+if [ "$(kubectl get pods joinchannel| grep joinchannel | wc -l | awk '{print $1}')" != "0" ]; then
     echo "Deleting Existing joinchannel pods"
     echo "Running: kubectl delete -f ${KUBECONFIG_FOLDER}/join_channel.yaml"
     kubectl delete -f ${KUBECONFIG_FOLDER}/join_channel.yaml
 
     # Wait for the pod to be deleted
-    while [ "$(kubectl get pods | grep joinchannel | wc -l | awk '{print $1}')" != "0" ]; do
+    while [ "$(kubectl get pods joinchannel | grep joinchannel | wc -l | awk '{print $1}')" != "0" ]; do
         echo "Waiting for old Join Channel to be deleted"
         sleep 1;
     done


### PR DESCRIPTION
Updated the scripts and k8s config files for enabling base ibm fabric 1.1 images to work with couchdb (free plan). Had to change the example for chaincode install and instantiate as chaincode_example02 does not work. Note that composer still has issues but the base fabric network can be started (you need to comment create/create_composer-playground.sh $@ in create_all.sh for this to work)