### PR TITLE
Update connection info used in composer-card-import.yaml

### DIFF
--- a/cs-offerings/kube-configs/composer-card-import.yaml
+++ b/cs-offerings/kube-configs/composer-card-import.yaml
@@ -26,19 +26,19 @@ spec:
           "version": "1.0.0",
           "peers": {
             "peer0.org1.example.com": {
-                "url": "grpc://localhost:7051",
-                "eventUrl": "grpc://localhost:7053"
+                "url": "grpc://blockchain-org1peer1:30110",
+                "eventUrl": "grpc://blockchain-org1peer1:30111"
               }
             },
+          "certificateAuthorities": {
             "ca.org1.example.com": {
-              "url": "http://localhost:7054",
-              "certificateAuthorities": {
-              "caName": "ca.org1.example.com"
+              "url": "http://blockchain-ca:30054",
+              "caName": "CA1"
             }
           },
           "orderers": {
             "orderer.example.com": {
-              "url": "grpc://localhost:7050"
+              "url": "grpc://blockchain-orderer:31010"
             }
           },
           "organizations": {


### PR DESCRIPTION
Updates the configuration used for the `connection.json` file used in the composer card import. Converts docker-style endpoints to match endpoints specified in `blockchain-serivces-*.yaml` files and sets the `caName` to match the value set in the `sampleconfig\cas\org1\ca.yaml` file.

Tested deploying with leveldb on IBM Kubernetes free cluster through creation of a business network and exposing as a REST API (step 6 of https://ibm-blockchain.github.io/interacting/ ).

Fixes issues #108 , #110  and supercedes PR #109 